### PR TITLE
Implement CourseDetail page

### DIFF
--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -1,16 +1,45 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
+import Button from '../components/Button'
 import { useParams } from 'react-router-dom'
 
 export default function CourseDetail() {
   const { id } = useParams()
+  const mockCourse = {
+    id: '1',
+    title: 'Introducción a JavaScript',
+    description: 'Aprendé los fundamentos de JavaScript desde cero.',
+    image: 'https://via.placeholder.com/800x300',
+    duration: '4 semanas',
+    level: 'Principiante',
+    classes: 8,
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="flex-grow p-4">
-        <h1 className="text-3xl font-bold mb-4">Detalle del curso {id}</h1>
-        <p>Información del curso próximamente...</p>
+      <main className="flex-grow p-4 flex flex-col items-start gap-4">
+        <img
+          src={mockCourse.image}
+          alt={mockCourse.title}
+          className="w-full h-48 object-cover rounded"
+        />
+        <h1 className="text-3xl font-bold">
+          {mockCourse.title} (ID: {id})
+        </h1>
+        <p>{mockCourse.description}</p>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <span className="px-3 py-1 bg-gray-200 rounded">
+            Nivel: {mockCourse.level}
+          </span>
+          <span className="px-3 py-1 bg-gray-200 rounded">
+            Duración: {mockCourse.duration}
+          </span>
+          <span className="px-3 py-1 bg-gray-200 rounded">
+            Clases: {mockCourse.classes}
+          </span>
+        </div>
+        <Button>Inscribirme</Button>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- build out `CourseDetail` page with mock data and styling
- display course information and an `Inscribirme` button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c5f5c1fc832f96f09a78820f9657