### PR TITLE
Add Dashboard page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Courses from './pages/Courses'
 import Login from './pages/Login'
 import CourseDetail from './pages/CourseDetail'
 import InscriptionSuccess from './pages/InscriptionSuccess'
+import Dashboard from './pages/Dashboard'
 
 export default function App() {
   return (
@@ -13,6 +14,7 @@ export default function App() {
       <Route path="/cursos/:id" element={<CourseDetail />} />
       <Route path="/login" element={<Login />} />
       <Route path="/inscripcion-exitosa" element={<InscriptionSuccess />} />
+      <Route path="/dashboard" element={<Dashboard />} />
     </Routes>
   )
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,44 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+
+export default function Dashboard() {
+  const enrolledCourses = [
+    {
+      id: '1',
+      title: 'Introducci\u00f3n a JavaScript',
+      progress: '3 de 8 clases',
+    },
+    {
+      id: '2',
+      title: 'React desde cero',
+      progress: '1 de 10 clases',
+    },
+  ]
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="flex-grow p-4">
+        <h1 className="text-3xl font-bold mb-4">Mis cursos</h1>
+        {enrolledCourses.length === 0 ? (
+          <p>Todav\u00eda no te inscribiste a ning\u00fan curso.</p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {enrolledCourses.map(course => (
+              <div
+                key={course.id}
+                className="border p-4 rounded shadow flex flex-col gap-2"
+              >
+                <h2 className="text-xl font-semibold">{course.title}</h2>
+                <p>{course.progress}</p>
+                <Button className="mt-auto">Continuar curso</Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create a Dashboard page showing a list of enrolled courses
- wire `/dashboard` route to render Dashboard component

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6856c8ab577c832fac002df49adedb1f