### PR TITLE
Add NotFound page and catch-all route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Login from './pages/Login'
 import CourseDetail from './pages/CourseDetail'
 import InscriptionSuccess from './pages/InscriptionSuccess'
 import Dashboard from './pages/Dashboard'
+import NotFound from './pages/NotFound'
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
       <Route path="/login" element={<Login />} />
       <Route path="/inscripcion-exitosa" element={<InscriptionSuccess />} />
       <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   )
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,19 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useNavigate } from 'react-router-dom'
+
+export default function NotFound() {
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="flex-grow flex flex-col items-center justify-center gap-4 p-4 text-center">
+        <h1 className="text-4xl font-bold">P\u00e1gina no encontrada</h1>
+        <p className="text-lg">La ruta que est\u00e1s buscando no existe.</p>
+        <Button onClick={() => navigate('/')}>Volver al inicio</Button>
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `NotFound` page for unmatched routes
- wire the new page up in routing with a catch-all

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6856ccc38e6c832f833ce0a469ad44e6