### PR TITLE
Implement mock course navigation

### DIFF
--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -1,22 +1,38 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
-import CourseCard from '../components/CourseCard'
+import { useNavigate } from 'react-router-dom'
 
-const mockCourses = [
-  { id: '1', title: 'React desde cero', duration: '8h', level: 'Básico' },
-  { id: '2', title: 'TypeScript avanzado', duration: '6h', level: 'Intermedio' },
-  { id: '3', title: 'Node.js APIs', duration: '10h', level: 'Avanzado' },
+const courses = [
+  {
+    id: '1',
+    title: 'JavaScript desde cero',
+    description: 'Curso introductorio a JS',
+  },
+  {
+    id: '2',
+    title: 'React intermedio',
+    description: 'Componentes, hooks y más',
+  },
 ]
 
 export default function Courses() {
+  const navigate = useNavigate()
+
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow p-4">
         <h1 className="text-3xl font-bold mb-4">Cursos disponibles</h1>
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {mockCourses.map(course => (
-            <CourseCard key={course.id} {...course} />
+          {courses.map(course => (
+            <div
+              key={course.id}
+              onClick={() => navigate(`/cursos/${course.id}`)}
+              className="border p-4 rounded shadow hover:shadow-lg cursor-pointer flex flex-col gap-2"
+            >
+              <h2 className="text-xl font-semibold">{course.title}</h2>
+              <p>{course.description}</p>
+            </div>
           ))}
         </div>
       </main>


### PR DESCRIPTION
## Summary
- add programmatic navigation to course list
- ensure NotFound route is present at the end of router

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6856ce8fc068832fa1b6aee79be507fd