### PR TITLE
Add course enrollment state

### DIFF
--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -2,10 +2,12 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../store/auth'
 
 export default function CourseDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const enroll = useAuthStore(state => state.enroll)
   const mockCourse = {
     id: '1',
     title: 'Introducción a JavaScript',
@@ -40,7 +42,18 @@ export default function CourseDetail() {
             Clases: {mockCourse.classes}
           </span>
         </div>
-        <Button onClick={() => navigate('/inscripcion-exitosa')}>Inscribirme</Button>
+        <Button
+          onClick={() => {
+            enroll({
+              id: '1',
+              title: 'JavaScript desde cero',
+              progress: '0 de 8 clases',
+            })
+            navigate('/inscripcion-exitosa')
+          }}
+        >
+          Inscribirme
+        </Button>
       </main>
       <Footer />
     </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,22 +2,10 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { useAuthStore } from '../store/auth'
 
 export default function Dashboard() {
-  const enrolledCourses = [
-    {
-      id: '1',
-      title: 'Introducci\u00f3n a JavaScript',
-      completed: 3,
-      total: 8,
-    },
-    {
-      id: '2',
-      title: 'React desde cero',
-      completed: 1,
-      total: 10,
-    },
-  ]
+  const enrolledCourses = useAuthStore(state => state.enrolledCourses)
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -29,9 +17,12 @@ export default function Dashboard() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
             {enrolledCourses.map(course => {
-              const remaining = course.total - course.completed
+              const match = course.progress.match(/(\d+) de (\d+)/)
+              const completed = match ? Number(match[1]) : 0
+              const total = match ? Number(match[2]) : 0
+              const remaining = total - completed
               const data = [
-                { name: 'Completado', value: course.completed },
+                { name: 'Completado', value: completed },
                 { name: 'Restante', value: remaining },
               ]
               return (
@@ -56,9 +47,7 @@ export default function Dashboard() {
                     </Pie>
                     <Tooltip />
                   </PieChart>
-                  <p className="text-sm">
-                    {course.completed} de {course.total} clases
-                  </p>
+                  <p className="text-sm">{course.progress}</p>
                   <Button className="mt-auto">Continuar curso</Button>
                 </div>
               )

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,10 +1,18 @@
 import { create } from 'zustand'
 
+export interface Course {
+  id: string
+  title: string
+  progress: string
+}
+
 export interface AuthState {
   isLogged: boolean
   user: Record<string, unknown> | null
+  enrolledCourses: Course[]
   login: (user: Record<string, unknown>) => void
   logout: () => void
+  enroll: (course: Course) => void
 }
 
 const useAuthStore = create<AuthState>((set) => {
@@ -14,14 +22,17 @@ const useAuthStore = create<AuthState>((set) => {
   return {
     isLogged: !!initialUser,
     user: initialUser,
+    enrolledCourses: [],
     login: (user) => {
       localStorage.setItem('user', JSON.stringify(user))
       set({ isLogged: true, user })
     },
     logout: () => {
       localStorage.removeItem('user')
-      set({ isLogged: false, user: null })
+      set({ isLogged: false, user: null, enrolledCourses: [] })
     },
+    enroll: course =>
+      set(state => ({ enrolledCourses: [...state.enrolledCourses, course] })),
   }
 })
 


### PR DESCRIPTION
## Summary
- extend auth store to track enrolled courses
- update course detail to enroll via store
- read enrolled courses in dashboard

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6856d61f02f8832fb38800a8032f26d9