### PR TITLE
Add missing screens and update navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,11 @@ import Login from './pages/Login'
 import CourseDetail from './pages/CourseDetail'
 import InscriptionSuccess from './pages/InscriptionSuccess'
 import Dashboard from './pages/Dashboard'
+import InscriptionForm from './pages/InscriptionForm'
+import Module from './pages/Module'
+import FinalExam from './pages/FinalExam'
+import Profile from './pages/Profile'
+import ErrorPage from './pages/ErrorPage'
 import NotFound from './pages/NotFound'
 
 export default function App() {
@@ -13,9 +18,14 @@ export default function App() {
       <Route path="/" element={<Home />} />
       <Route path="/cursos" element={<Courses />} />
       <Route path="/cursos/:id" element={<CourseDetail />} />
+      <Route path="/cursos/:id/inscripcion" element={<InscriptionForm />} />
+      <Route path="/cursos/:id/modulo/:moduleId" element={<Module />} />
+      <Route path="/cursos/:id/examen-final" element={<FinalExam />} />
       <Route path="/login" element={<Login />} />
       <Route path="/inscripcion-exitosa" element={<InscriptionSuccess />} />
       <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/perfil" element={<Profile />} />
+      <Route path="/error" element={<ErrorPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,6 +12,12 @@ export default function Navbar() {
     <nav className="p-4 flex flex-wrap items-center gap-4 bg-gray-200 dark:bg-gray-800 text-sm">
       <Link to="/" className="block">Home</Link>
       <Link to="/cursos" className="block">Cursos</Link>
+      {isLogged && (
+        <>
+          <Link to="/dashboard" className="block">Mis cursos</Link>
+          <Link to="/perfil" className="block">Perfil</Link>
+        </>
+      )}
       <div className="ml-auto flex flex-wrap items-center gap-2">
         {isLogged ? (
           <>

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '../store/auth'
 export default function CourseDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const enroll = useAuthStore(state => state.enroll)
+  const isLogged = useAuthStore(state => state.isLogged)
   const mockCourse = {
     id: '1',
     title: 'Introducción a JavaScript',
@@ -44,12 +44,11 @@ export default function CourseDetail() {
         </div>
         <Button
           onClick={() => {
-            enroll({
-              id: '1',
-              title: 'JavaScript desde cero',
-              progress: '0 de 8 clases',
-            })
-            navigate('/inscripcion-exitosa')
+            if (!isLogged) {
+              navigate('/login')
+            } else {
+              navigate(`/cursos/${id}/inscripcion`)
+            }
           }}
         >
           Inscribirme

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,9 +3,11 @@ import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { PieChart, Pie, Cell, Tooltip } from 'recharts'
 import { useAuthStore } from '../store/auth'
+import { useNavigate } from 'react-router-dom'
 
 export default function Dashboard() {
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
+  const navigate = useNavigate()
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -48,7 +50,12 @@ export default function Dashboard() {
                     <Tooltip />
                   </PieChart>
                   <p className="text-sm">{course.progress}</p>
-                  <Button className="mt-auto">Continuar curso</Button>
+                  <Button
+                    className="mt-auto"
+                    onClick={() => navigate(`/cursos/${course.id}/modulo/1`)}
+                  >
+                    Continuar curso
+                  </Button>
                 </div>
               )
             })}

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,19 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useNavigate } from 'react-router-dom'
+
+export default function ErrorPage() {
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-4 p-4 text-center">
+        <h1 className="text-4xl font-bold">Ocurrió un error</h1>
+        <p className="text-lg">Intenta nuevamente más tarde.</p>
+        <Button onClick={() => navigate('/')}>Volver al inicio</Button>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -1,0 +1,20 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useNavigate, useParams } from 'react-router-dom'
+
+export default function FinalExam() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Examen final - Curso {id}</h1>
+        <p>Completa las preguntas para finalizar el curso.</p>
+        <Button onClick={() => navigate('/dashboard')}>Enviar respuestas</Button>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/pages/InscriptionForm.tsx
+++ b/src/pages/InscriptionForm.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useAuthStore } from '../store/auth'
+
+export default function InscriptionForm() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { isLogged, enroll } = useAuthStore()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+
+  useEffect(() => {
+    if (!isLogged) navigate('/login')
+  }, [isLogged, navigate])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    enroll({ id: id || '', title: `Curso ${id}`, progress: '0 de 8 clases' })
+    navigate('/inscripcion-exitosa', { state: { courseTitle: `Curso ${id}` } })
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Inscripción al curso {id}</h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm">
+          <input
+            className="border p-2 rounded"
+            placeholder="Nombre"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+          />
+          <input
+            type="email"
+            className="border p-2 rounded"
+            placeholder="Email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <Button type="submit">Confirmar inscripción</Button>
+        </form>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/pages/InscriptionSuccess.tsx
+++ b/src/pages/InscriptionSuccess.tsx
@@ -1,11 +1,12 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 
 export default function InscriptionSuccess() {
   const navigate = useNavigate()
-  const courseName = 'Introducción a JavaScript'
+  const location = useLocation()
+  const courseName = (location.state as { courseTitle?: string } | null)?.courseTitle ?? 'Introducción a JavaScript'
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -1,0 +1,23 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useNavigate, useParams } from 'react-router-dom'
+
+export default function Module() {
+  const { id, moduleId } = useParams()
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Curso {id} - Módulo {moduleId}</h1>
+        <div className="aspect-video bg-gray-200 flex items-center justify-center">
+          Contenido del módulo {moduleId}
+        </div>
+        <Button onClick={() => navigate(-1)}>Marcar completado</Button>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+import Button from '../components/Button'
+import { useAuthStore } from '../store/auth'
+
+export default function Profile() {
+  const { user } = useAuthStore()
+  const [name, setName] = useState((user as { name?: string } | null)?.name || '')
+  const [email, setEmail] = useState((user as { email?: string } | null)?.email || '')
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Perfil de usuario</h1>
+        <div className="flex flex-col gap-4 max-w-sm">
+          <input className="border p-2 rounded" value={name} onChange={e => setName(e.target.value)} placeholder="Nombre" />
+          <input className="border p-2 rounded" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+          <Button>Guardar cambios</Button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add several new pages: registration form, module view, exam, profile and error
- link new screens from router and update course detail link
- update dashboard to link to module view
- read course name from navigation state after enrolling
- extend navbar with dashboard and profile links for logged-in users

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6856dbd0a904832fa0d8bd431125a155