### PR TITLE
Improve dark mode and courses

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 
-export default function DarkModeToggle() {
+interface Props {
+  className?: string
+}
+
+export default function DarkModeToggle({ className = '' }: Props) {
   const [enabled, setEnabled] = useState(false)
 
   useEffect(() => {
@@ -14,7 +18,7 @@ export default function DarkModeToggle() {
   return (
     <button
       onClick={() => setEnabled(!enabled)}
-      className="ml-4 px-4 py-2 border rounded min-w-[6rem] text-sm"
+      className={`px-4 py-2 border rounded min-w-[6rem] text-sm ${className}`}
     >
       {enabled ? 'Modo claro' : 'Modo oscuro'}
     </button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,7 +32,7 @@ export default function Navbar() {
             </svg>
           )}
         </button>
-        <DarkModeToggle />
+        <DarkModeToggle className="ml-4" />
       </div>
       <div className={`${open ? 'flex' : 'hidden'} sm:flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 border-t sm:border-none`}>
         <Link to="/" className="block" onClick={() => setOpen(false)}>Home</Link>
@@ -66,6 +66,7 @@ export default function Navbar() {
               Ingresar
             </button>
           )}
+          <DarkModeToggle className="hidden sm:block" />
         </div>
       </div>
     </nav>

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,0 +1,145 @@
+export interface ModuleInfo {
+  id: string
+  title: string
+}
+
+export interface CourseInfo {
+  id: string
+  title: string
+  description: string
+  image: string
+  duration: string
+  level: string
+  modules: ModuleInfo[]
+}
+
+export const courses: CourseInfo[] = [
+  {
+    id: 'html-css',
+    title: 'HTML y CSS desde cero',
+    description:
+      'Aprende a construir paginas web modernas con HTML5 y CSS3 paso a paso.',
+    image: '/images/course-html-css.png',
+    duration: '4 semanas',
+    level: 'Principiante',
+    modules: [
+      { id: '1', title: 'Introducción al desarrollo web' },
+      { id: '2', title: 'Estructura con HTML' },
+      { id: '3', title: 'Estilos con CSS' },
+      { id: '4', title: 'Diseño responsive' },
+      { id: '5', title: 'Proyecto final' },
+    ],
+  },
+  {
+    id: 'javascript-basico',
+    title: 'JavaScript desde cero',
+    description:
+      'Domina los fundamentos del lenguaje que impulsa la web moderna.',
+    image: '/images/course-js.png',
+    duration: '5 semanas',
+    level: 'Principiante',
+    modules: [
+      { id: '1', title: 'Sintaxis y variables' },
+      { id: '2', title: 'Funciones y objetos' },
+      { id: '3', title: 'DOM y eventos' },
+      { id: '4', title: 'Manejo de asincronía' },
+      { id: '5', title: 'Consumo de APIs' },
+      { id: '6', title: 'Proyecto integrador' },
+    ],
+  },
+  {
+    id: 'react-principiantes',
+    title: 'React para principiantes',
+    description: 'Crea interfaces interactivas con la librería más popular.',
+    image: '/images/course-react.png',
+    duration: '6 semanas',
+    level: 'Intermedio',
+    modules: [
+      { id: '1', title: 'Componentes y JSX' },
+      { id: '2', title: 'Estado y propiedades' },
+      { id: '3', title: 'Hooks básicos' },
+      { id: '4', title: 'Ruteo con React Router' },
+      { id: '5', title: 'Proyecto guiado' },
+    ],
+  },
+  {
+    id: 'node-express',
+    title: 'Node.js y Express',
+    description: 'Construye servidores y APIs con JavaScript del lado del servidor.',
+    image: '/images/course-node.png',
+    duration: '5 semanas',
+    level: 'Intermedio',
+    modules: [
+      { id: '1', title: 'Introducción a Node.js' },
+      { id: '2', title: 'Módulos y NPM' },
+      { id: '3', title: 'Creación de API con Express' },
+      { id: '4', title: 'Persistencia con bases de datos' },
+      { id: '5', title: 'Despliegue' },
+    ],
+  },
+  {
+    id: 'typescript-avanzado',
+    title: 'TypeScript avanzado',
+    description: 'Lleva tu código JavaScript al siguiente nivel con tipado fuerte.',
+    image: '/images/course-ts.png',
+    duration: '6 semanas',
+    level: 'Avanzado',
+    modules: [
+      { id: '1', title: 'Tipos y interfaces' },
+      { id: '2', title: 'Genéricos' },
+      { id: '3', title: 'Decoradores y metadata' },
+      { id: '4', title: 'Configuración avanzada' },
+      { id: '5', title: 'Integración con librerías' },
+      { id: '6', title: 'Patrones de diseño' },
+      { id: '7', title: 'Proyecto final' },
+    ],
+  },
+  {
+    id: 'mern-fullstack',
+    title: 'Desarrollo Fullstack con MERN',
+    description: 'Aprende a crear aplicaciones completas con Mongo, Express, React y Node.',
+    image: '/images/course-mern.png',
+    duration: '8 semanas',
+    level: 'Avanzado',
+    modules: [
+      { id: '1', title: 'Fundamentos de MongoDB' },
+      { id: '2', title: 'API REST con Express' },
+      { id: '3', title: 'Frontend con React' },
+      { id: '4', title: 'Autenticación' },
+      { id: '5', title: 'Testing' },
+      { id: '6', title: 'Despliegue continuo' },
+      { id: '7', title: 'Proyecto final' },
+    ],
+  },
+  {
+    id: 'testing-jest',
+    title: 'Testing con Jest',
+    description: 'Garantiza la calidad de tus aplicaciones con pruebas unitarias y de integración.',
+    image: '/images/course-jest.png',
+    duration: '4 semanas',
+    level: 'Intermedio',
+    modules: [
+      { id: '1', title: 'Introducción a las pruebas' },
+      { id: '2', title: 'Jest en profundidad' },
+      { id: '3', title: 'Pruebas de React' },
+      { id: '4', title: 'Cobertura y mocks' },
+      { id: '5', title: 'Integración continua' },
+    ],
+  },
+  {
+    id: 'react-native',
+    title: 'Aplicaciones móviles con React Native',
+    description: 'Desarrolla apps nativas para iOS y Android usando JavaScript.',
+    image: '/images/course-react-native.png',
+    duration: '7 semanas',
+    level: 'Intermedio',
+    modules: [
+      { id: '1', title: 'Bases de React Native' },
+      { id: '2', title: 'Componentes y estilos' },
+      { id: '3', title: 'Navegación en la app' },
+      { id: '4', title: 'Consumo de APIs' },
+      { id: '5', title: 'Distribución en tiendas' },
+      { id: '6', title: 'Proyecto final' },
+    ],
+  },
+]

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -1,47 +1,47 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuthStore } from '../store/auth'
+import { courses } from '../data/courses'
 
 export default function CourseDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const isLogged = useAuthStore(state => state.isLogged)
-  const mockCourse = {
-    id: '1',
-    title: 'Introducción a JavaScript',
-    description: 'Aprendé los fundamentos de JavaScript desde cero.',
-    image: 'https://via.placeholder.com/800x300',
-    duration: '4 semanas',
-    level: 'Principiante',
-    classes: 8,
-  }
+  const course = courses.find(c => c.id === id)
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 flex flex-col items-start gap-4">
-        <img
-          src={mockCourse.image}
-          alt={mockCourse.title}
-          className="w-full max-w-full h-auto object-cover rounded overflow-hidden"
-        />
-        <h1 className="text-3xl font-bold">
-          {mockCourse.title} (ID: {id})
-        </h1>
-        <p>{mockCourse.description}</p>
-        <div className="flex flex-wrap gap-2 text-sm">
-          <span className="px-3 py-1 bg-gray-200 rounded">
-            Nivel: {mockCourse.level}
-          </span>
-          <span className="px-3 py-1 bg-gray-200 rounded">
-            Duración: {mockCourse.duration}
-          </span>
-          <span className="px-3 py-1 bg-gray-200 rounded">
-            Clases: {mockCourse.classes}
-          </span>
-        </div>
+        {course ? (
+          <>
+            <img
+              src={course.image}
+              alt={course.title}
+              className="w-full max-w-full h-auto object-cover rounded overflow-hidden"
+            />
+            <h1 className="text-3xl font-bold">{course.title}</h1>
+            <p>{course.description}</p>
+            <div className="flex flex-wrap gap-2 text-sm">
+              <span className="px-3 py-1 bg-gray-200 rounded">Nivel: {course.level}</span>
+              <span className="px-3 py-1 bg-gray-200 rounded">Duración: {course.duration}</span>
+              <span className="px-3 py-1 bg-gray-200 rounded">Módulos: {course.modules.length}</span>
+            </div>
+            <ul className="list-disc pl-6 space-y-1">
+              {course.modules.map(m => (
+                <li key={m.id}>
+                  <Link to={`/cursos/${id}/modulo/${m.id}`} className="text-blue-600 underline">
+                    {m.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p>Curso no encontrado</p>
+        )}
         <Button
           onClick={() => {
             if (!isLogged) {

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -1,22 +1,9 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
-import { useNavigate } from 'react-router-dom'
-
-const courses = [
-  {
-    id: '1',
-    title: 'JavaScript desde cero',
-    description: 'Curso introductorio a JS',
-  },
-  {
-    id: '2',
-    title: 'React intermedio',
-    description: 'Componentes, hooks y más',
-  },
-]
+import { courses } from '../data/courses'
+import CourseCard from '../components/CourseCard'
 
 export default function Courses() {
-  const navigate = useNavigate()
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -25,14 +12,13 @@ export default function Courses() {
         <h1 className="text-3xl font-bold mb-4">Cursos disponibles</h1>
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
           {courses.map(course => (
-            <div
+            <CourseCard
               key={course.id}
-              onClick={() => navigate(`/cursos/${course.id}`)}
-              className="border p-4 rounded shadow hover:shadow-lg cursor-pointer flex flex-col gap-2"
-            >
-              <h2 className="text-xl font-semibold">{course.title}</h2>
-              <p>{course.description}</p>
-            </div>
+              id={course.id}
+              title={course.title}
+              duration={course.duration}
+              level={course.level}
+            />
           ))}
         </div>
       </main>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,9 +19,8 @@ export default function Dashboard() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
             {enrolledCourses.map(course => {
-              const match = course.progress.match(/(\d+) de (\d+)/)
-              const completed = match ? Number(match[1]) : 0
-              const total = match ? Number(match[2]) : 0
+              const completed = course.completed
+              const total = course.total
               const remaining = total - completed
               const data = [
                 { name: 'Completado', value: completed },
@@ -49,10 +48,14 @@ export default function Dashboard() {
                     </Pie>
                     <Tooltip />
                   </PieChart>
-                  <p className="text-sm">{course.progress}</p>
+                  <p className="text-sm">
+                    {course.completed} de {course.total} módulos
+                  </p>
                   <Button
                     className="mt-auto"
-                    onClick={() => navigate(`/cursos/${course.id}/modulo/1`)}
+                    onClick={() =>
+                      navigate(`/cursos/${course.id}/modulo/${course.completed + 1}`)
+                    }
                   >
                     Continuar curso
                   </Button>

--- a/src/pages/InscriptionForm.tsx
+++ b/src/pages/InscriptionForm.tsx
@@ -4,6 +4,7 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { useAuthStore } from '../store/auth'
+import { courses } from '../data/courses'
 
 export default function InscriptionForm() {
   const { id } = useParams()
@@ -18,8 +19,14 @@ export default function InscriptionForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    enroll({ id: id || '', title: `Curso ${id}`, progress: '0 de 8 clases' })
-    navigate('/inscripcion-exitosa', { state: { courseTitle: `Curso ${id}` } })
+    const course = courses.find(c => c.id === id)
+    enroll({
+      id: id || '',
+      title: course?.title ?? `Curso ${id}`,
+      completed: 0,
+      total: course?.modules.length ?? 0,
+    })
+    navigate('/inscripcion-exitosa', { state: { courseTitle: course?.title } })
   }
 
   return (

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -2,20 +2,41 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { useNavigate, useParams } from 'react-router-dom'
+import { courses } from '../data/courses'
+import { useAuthStore } from '../store/auth'
 
 export default function Module() {
   const { id, moduleId } = useParams()
   const navigate = useNavigate()
+  const isLogged = useAuthStore(state => state.isLogged)
+  const complete = useAuthStore(state => state.completeModule)
+  const course = courses.find(c => c.id === id)
+  const module = course?.modules.find(m => m.id === moduleId)
+
+  const handleComplete = () => {
+    if (!isLogged) {
+      navigate('/login')
+    } else {
+      if (id) complete(id)
+      navigate(-1)
+    }
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 space-y-4">
-        <h1 className="text-3xl font-bold">Curso {id} - Módulo {moduleId}</h1>
-        <div className="aspect-video bg-gray-200 flex items-center justify-center">
-          Contenido del módulo {moduleId}
-        </div>
-        <Button onClick={() => navigate(-1)}>Marcar completado</Button>
+        {course && module ? (
+          <>
+            <h1 className="text-3xl font-bold">{course.title} - {module.title}</h1>
+            <div className="aspect-video bg-gray-200 flex items-center justify-center">
+              Contenido del módulo {moduleId}
+            </div>
+          </>
+        ) : (
+          <p>Módulo no encontrado</p>
+        )}
+        <Button onClick={handleComplete}>Marcar completado</Button>
       </main>
       <Footer />
     </div>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -3,7 +3,8 @@ import { create } from 'zustand'
 export interface Course {
   id: string
   title: string
-  progress: string
+  completed: number
+  total: number
 }
 
 export interface AuthState {
@@ -13,6 +14,7 @@ export interface AuthState {
   login: (user: Record<string, unknown>) => void
   logout: () => void
   enroll: (course: Course) => void
+  completeModule: (courseId: string) => void
 }
 
 const useAuthStore = create<AuthState>((set) => {
@@ -33,6 +35,14 @@ const useAuthStore = create<AuthState>((set) => {
     },
     enroll: course =>
       set(state => ({ enrolledCourses: [...state.enrolledCourses, course] })),
+    completeModule: courseId =>
+      set(state => ({
+        enrolledCourses: state.enrolledCourses.map(c =>
+          c.id === courseId && c.completed < c.total
+            ? { ...c, completed: c.completed + 1 }
+            : c,
+        ),
+      })),
   }
 })
 


### PR DESCRIPTION
## Summary
- enhance DarkModeToggle to accept custom classes
- show dark mode toggle on desktop
- add a static catalog of real programming courses
- update pages to display course catalog
- support enrolling and tracking module completion
- show module titles and allow marking them as complete

## Testing
- `pnpm install` *(fails: packages field missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4491e3c832fad36e667886d938b