### PR TITLE
Add course progress controls

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,6 +1,8 @@
 export interface ModuleInfo {
   id: string
   title: string
+  description: string
+  videoUrl: string
 }
 
 export interface CourseInfo {
@@ -23,11 +25,11 @@ export const courses: CourseInfo[] = [
     duration: '4 semanas',
     level: 'Principiante',
     modules: [
-      { id: '1', title: 'Introducción al desarrollo web' },
-      { id: '2', title: 'Estructura con HTML' },
-      { id: '3', title: 'Estilos con CSS' },
-      { id: '4', title: 'Diseño responsive' },
-      { id: '5', title: 'Proyecto final' },
+      { id: '1', title: 'Introducción al desarrollo web', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Estructura con HTML', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Estilos con CSS', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Diseño responsive', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Proyecto final', description: 'Contenido del módulo 5', videoUrl: '#' },
     ],
   },
   {
@@ -39,12 +41,12 @@ export const courses: CourseInfo[] = [
     duration: '5 semanas',
     level: 'Principiante',
     modules: [
-      { id: '1', title: 'Sintaxis y variables' },
-      { id: '2', title: 'Funciones y objetos' },
-      { id: '3', title: 'DOM y eventos' },
-      { id: '4', title: 'Manejo de asincronía' },
-      { id: '5', title: 'Consumo de APIs' },
-      { id: '6', title: 'Proyecto integrador' },
+      { id: '1', title: 'Sintaxis y variables', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Funciones y objetos', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'DOM y eventos', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Manejo de asincronía', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Consumo de APIs', description: 'Contenido del módulo 5', videoUrl: '#' },
+      { id: '6', title: 'Proyecto integrador', description: 'Contenido del módulo 6', videoUrl: '#' },
     ],
   },
   {
@@ -55,11 +57,11 @@ export const courses: CourseInfo[] = [
     duration: '6 semanas',
     level: 'Intermedio',
     modules: [
-      { id: '1', title: 'Componentes y JSX' },
-      { id: '2', title: 'Estado y propiedades' },
-      { id: '3', title: 'Hooks básicos' },
-      { id: '4', title: 'Ruteo con React Router' },
-      { id: '5', title: 'Proyecto guiado' },
+      { id: '1', title: 'Componentes y JSX', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Estado y propiedades', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Hooks básicos', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Ruteo con React Router', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Proyecto guiado', description: 'Contenido del módulo 5', videoUrl: '#' },
     ],
   },
   {
@@ -70,11 +72,11 @@ export const courses: CourseInfo[] = [
     duration: '5 semanas',
     level: 'Intermedio',
     modules: [
-      { id: '1', title: 'Introducción a Node.js' },
-      { id: '2', title: 'Módulos y NPM' },
-      { id: '3', title: 'Creación de API con Express' },
-      { id: '4', title: 'Persistencia con bases de datos' },
-      { id: '5', title: 'Despliegue' },
+      { id: '1', title: 'Introducción a Node.js', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Módulos y NPM', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Creación de API con Express', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Persistencia con bases de datos', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Despliegue', description: 'Contenido del módulo 5', videoUrl: '#' },
     ],
   },
   {
@@ -85,13 +87,13 @@ export const courses: CourseInfo[] = [
     duration: '6 semanas',
     level: 'Avanzado',
     modules: [
-      { id: '1', title: 'Tipos y interfaces' },
-      { id: '2', title: 'Genéricos' },
-      { id: '3', title: 'Decoradores y metadata' },
-      { id: '4', title: 'Configuración avanzada' },
-      { id: '5', title: 'Integración con librerías' },
-      { id: '6', title: 'Patrones de diseño' },
-      { id: '7', title: 'Proyecto final' },
+      { id: '1', title: 'Tipos y interfaces', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Genéricos', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Decoradores y metadata', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Configuración avanzada', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Integración con librerías', description: 'Contenido del módulo 5', videoUrl: '#' },
+      { id: '6', title: 'Patrones de diseño', description: 'Contenido del módulo 6', videoUrl: '#' },
+      { id: '7', title: 'Proyecto final', description: 'Contenido del módulo 7', videoUrl: '#' },
     ],
   },
   {
@@ -102,13 +104,13 @@ export const courses: CourseInfo[] = [
     duration: '8 semanas',
     level: 'Avanzado',
     modules: [
-      { id: '1', title: 'Fundamentos de MongoDB' },
-      { id: '2', title: 'API REST con Express' },
-      { id: '3', title: 'Frontend con React' },
-      { id: '4', title: 'Autenticación' },
-      { id: '5', title: 'Testing' },
-      { id: '6', title: 'Despliegue continuo' },
-      { id: '7', title: 'Proyecto final' },
+      { id: '1', title: 'Fundamentos de MongoDB', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'API REST con Express', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Frontend con React', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Autenticación', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Testing', description: 'Contenido del módulo 5', videoUrl: '#' },
+      { id: '6', title: 'Despliegue continuo', description: 'Contenido del módulo 6', videoUrl: '#' },
+      { id: '7', title: 'Proyecto final', description: 'Contenido del módulo 7', videoUrl: '#' },
     ],
   },
   {
@@ -119,11 +121,11 @@ export const courses: CourseInfo[] = [
     duration: '4 semanas',
     level: 'Intermedio',
     modules: [
-      { id: '1', title: 'Introducción a las pruebas' },
-      { id: '2', title: 'Jest en profundidad' },
-      { id: '3', title: 'Pruebas de React' },
-      { id: '4', title: 'Cobertura y mocks' },
-      { id: '5', title: 'Integración continua' },
+      { id: '1', title: 'Introducción a las pruebas', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Jest en profundidad', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Pruebas de React', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Cobertura y mocks', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Integración continua', description: 'Contenido del módulo 5', videoUrl: '#' },
     ],
   },
   {
@@ -134,12 +136,12 @@ export const courses: CourseInfo[] = [
     duration: '7 semanas',
     level: 'Intermedio',
     modules: [
-      { id: '1', title: 'Bases de React Native' },
-      { id: '2', title: 'Componentes y estilos' },
-      { id: '3', title: 'Navegación en la app' },
-      { id: '4', title: 'Consumo de APIs' },
-      { id: '5', title: 'Distribución en tiendas' },
-      { id: '6', title: 'Proyecto final' },
+      { id: '1', title: 'Bases de React Native', description: 'Contenido del módulo 1', videoUrl: '#' },
+      { id: '2', title: 'Componentes y estilos', description: 'Contenido del módulo 2', videoUrl: '#' },
+      { id: '3', title: 'Navegación en la app', description: 'Contenido del módulo 3', videoUrl: '#' },
+      { id: '4', title: 'Consumo de APIs', description: 'Contenido del módulo 4', videoUrl: '#' },
+      { id: '5', title: 'Distribución en tiendas', description: 'Contenido del módulo 5', videoUrl: '#' },
+      { id: '6', title: 'Proyecto final', description: 'Contenido del módulo 6', videoUrl: '#' },
     ],
   },
 ]

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -2,6 +2,7 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect } from 'react'
 import { courses } from '../data/courses'
 import { useAuthStore } from '../store/auth'
 
@@ -10,16 +11,33 @@ export default function Module() {
   const navigate = useNavigate()
   const isLogged = useAuthStore(state => state.isLogged)
   const complete = useAuthStore(state => state.completeModule)
+  const progress = useAuthStore(state =>
+    state.enrolledCourses.find(c => c.id === id),
+  )
+  const setCurrentCourse = useAuthStore(state => state.setCurrentCourse)
   const course = courses.find(c => c.id === id)
   const module = course?.modules.find(m => m.id === moduleId)
+
+  useEffect(() => {
+    if (id) setCurrentCourse(id)
+    const expected = progress ? progress.completed + 1 : 1
+    if (module && parseInt(module.id) !== expected) {
+      navigate(`/cursos/${id}/modulo/${expected}`, { replace: true })
+    }
+  }, [id, module, progress, navigate, setCurrentCourse])
 
   const handleComplete = () => {
     if (!isLogged) {
       navigate('/login')
-    } else {
-      if (id) complete(id)
-      navigate(-1)
+      return
     }
+    if (!progress || progress.completed < progress.total) {
+      if (id) complete(id)
+      if (progress && progress.completed + 1 >= progress.total) {
+        setCurrentCourse(null)
+      }
+    }
+    navigate(-1)
   }
 
   return (
@@ -29,6 +47,10 @@ export default function Module() {
         {course && module ? (
           <>
             <h1 className="text-3xl font-bold">{course.title} - {module.title}</h1>
+            <p>{module.description}</p>
+            <a href={module.videoUrl} className="text-blue-600 underline" target="_blank" rel="noreferrer">
+              Ver video
+            </a>
             <div className="aspect-video bg-gray-200 flex items-center justify-center">
               Contenido del módulo {moduleId}
             </div>
@@ -36,7 +58,11 @@ export default function Module() {
         ) : (
           <p>Módulo no encontrado</p>
         )}
-        <Button onClick={handleComplete}>Marcar completado</Button>
+        <Button onClick={handleComplete} disabled={progress?.completed >= progress?.total}>
+          {progress && progress.completed >= progress.total
+            ? 'Curso completado'
+            : 'Marcar completado'}
+        </Button>
       </main>
       <Footer />
     </div>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -11,27 +11,32 @@ export interface AuthState {
   isLogged: boolean
   user: Record<string, unknown> | null
   enrolledCourses: Course[]
+  currentCourseId: string | null
   login: (user: Record<string, unknown>) => void
   logout: () => void
   enroll: (course: Course) => void
   completeModule: (courseId: string) => void
+  setCurrentCourse: (courseId: string | null) => void
 }
 
 const useAuthStore = create<AuthState>((set) => {
   const stored = localStorage.getItem('user')
   const initialUser = stored ? JSON.parse(stored) : null
+  const storedCourse = localStorage.getItem('currentCourseId')
 
   return {
     isLogged: !!initialUser,
     user: initialUser,
     enrolledCourses: [],
+    currentCourseId: storedCourse,
     login: (user) => {
       localStorage.setItem('user', JSON.stringify(user))
       set({ isLogged: true, user })
     },
     logout: () => {
       localStorage.removeItem('user')
-      set({ isLogged: false, user: null, enrolledCourses: [] })
+      localStorage.removeItem('currentCourseId')
+      set({ isLogged: false, user: null, enrolledCourses: [], currentCourseId: null })
     },
     enroll: course =>
       set(state => ({ enrolledCourses: [...state.enrolledCourses, course] })),
@@ -43,6 +48,14 @@ const useAuthStore = create<AuthState>((set) => {
             : c,
         ),
       })),
+    setCurrentCourse: courseId => {
+      if (courseId) {
+        localStorage.setItem('currentCourseId', courseId)
+      } else {
+        localStorage.removeItem('currentCourseId')
+      }
+      set({ currentCourseId: courseId })
+    },
   }
 })
 


### PR DESCRIPTION
## Summary
- extend course module metadata
- track active course in auth store
- enforce module order and prevent double completion
- show module text and video link

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --project tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6856fa7970ac832f98979dbfe442855c