### PR TITLE
Restrict course features to logged users

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { useAuthStore } from '../store/auth'
 
 interface Props {
   id: string
@@ -8,11 +9,23 @@ interface Props {
 }
 
 export default function CourseCard({ id, title, duration, level }: Props) {
+  const isLogged = useAuthStore(state => state.isLogged)
+
   return (
-    <Link to={`/cursos/${id}`} className="border p-4 rounded shadow hover:shadow-lg flex flex-col gap-2 w-full">
-      <h2 className="text-xl font-semibold">{title}</h2>
-      <p>Duración: {duration}</p>
-      <p>Nivel: {level}</p>
-    </Link>
+    <div className="border p-4 rounded shadow hover:shadow-lg flex flex-col gap-2 w-full">
+      <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p>Duración: {duration}</p>
+        <p>Nivel: {level}</p>
+      </Link>
+      {!isLogged && (
+        <Link
+          to="/login"
+          className="mt-2 px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
+        >
+          Inicia sesión para inscribirte
+        </Link>
+      )}
+    </div>
   )
 }

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -31,15 +31,20 @@ export default function CourseDetail() {
               <span className="px-3 py-1 bg-gray-200 rounded">Duración: {course.duration}</span>
               <span className="px-3 py-1 bg-gray-200 rounded">Módulos: {course.modules.length}</span>
             </div>
-            <ul className="list-disc pl-6 space-y-1">
-            {course.modules.map(m => (
-              <li key={m.id}>
-                <Link to={`/cursos/${id}/modulo/${m.id}`} className="text-blue-600 underline">
-                  {m.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
+            <ul className="list-disc pl-6 space-y-2">
+              {course.modules.map(m => (
+                <li key={m.id} className="space-y-1">
+                  {isLogged ? (
+                    <Link to={`/cursos/${id}/modulo/${m.id}`} className="text-blue-600 underline">
+                      {m.title}
+                    </Link>
+                  ) : (
+                    <span className="font-semibold">{m.title}</span>
+                  )}
+                  <p className="ml-4 text-sm text-gray-600">{m.description}</p>
+                </li>
+              ))}
+            </ul>
           {progress && (
             <p className="font-semibold">
               {progress.completed >= progress.total
@@ -70,7 +75,9 @@ export default function CourseDetail() {
             ? progress.completed >= progress.total
               ? 'Curso finalizado'
               : `Continuar curso (${Math.round((progress.completed / progress.total) * 100)}%)`
-            : 'Inscribirme'}
+            : isLogged
+              ? 'Inscribirme'
+              : 'Inicia sesión para inscribirte'}
         </Button>
       </main>
       <Footer />

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -2,24 +2,57 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import { courses } from '../data/courses'
 import CourseCard from '../components/CourseCard'
+import { useAuthStore } from '../store/auth'
 
 export default function Courses() {
+  const { isLogged, enrolledCourses } = useAuthStore()
+  const availableCourses = courses.filter(
+    c => !enrolledCourses.some(e => e.id === c.id),
+  )
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
-        <h1 className="text-3xl font-bold mb-4">Cursos disponibles</h1>
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {courses.map(course => (
-            <CourseCard
-              key={course.id}
-              id={course.id}
-              title={course.title}
-              duration={course.duration}
-              level={course.level}
-            />
-          ))}
+      <main className="container mx-auto flex-grow p-4 space-y-6">
+        {isLogged && (
+          <div className="space-y-4">
+            <h1 className="text-3xl font-bold">Mis cursos</h1>
+            {enrolledCourses.length === 0 ? (
+              <p>Aún no estás inscrito en ningún curso.</p>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                {enrolledCourses.map(course => {
+                  const info = courses.find(c => c.id === course.id)
+                  return (
+                    <CourseCard
+                      key={course.id}
+                      id={course.id}
+                      title={info?.title ?? course.title}
+                      duration={info?.duration ?? ''}
+                      level={info?.level ?? ''}
+                    />
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold">
+            {isLogged ? 'Todos los cursos' : 'Cursos disponibles'}
+          </h1>
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {(isLogged ? availableCourses : courses).map(course => (
+              <CourseCard
+                key={course.id}
+                id={course.id}
+                title={course.title}
+                duration={course.duration}
+                level={course.level}
+              />
+            ))}
+          </div>
         </div>
       </main>
       <Footer />

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -48,21 +48,39 @@ export default function Module() {
           <>
             <h1 className="text-3xl font-bold">{course.title} - {module.title}</h1>
             <p>{module.description}</p>
-            <a href={module.videoUrl} className="text-blue-600 underline" target="_blank" rel="noreferrer">
-              Ver video
-            </a>
-            <div className="aspect-video bg-gray-200 flex items-center justify-center">
-              Contenido del módulo {moduleId}
-            </div>
+            {isLogged ? (
+              <>
+                <a
+                  href={module.videoUrl}
+                  className="text-blue-600 underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Ver video
+                </a>
+                <div className="aspect-video bg-gray-200 flex items-center justify-center">
+                  Contenido del módulo {moduleId}
+                </div>
+              </>
+            ) : (
+              <p className="italic">Inicia sesión para ver el contenido de este módulo.</p>
+            )}
           </>
         ) : (
           <p>Módulo no encontrado</p>
         )}
-        <Button onClick={handleComplete} disabled={progress?.completed >= progress?.total}>
-          {progress && progress.completed >= progress.total
-            ? 'Curso completado'
-            : 'Marcar completado'}
-        </Button>
+        {isLogged ? (
+          <Button
+            onClick={handleComplete}
+            disabled={progress ? progress.completed >= progress.total : false}
+          >
+            {progress && progress.completed >= progress.total
+              ? 'Curso completado'
+              : 'Marcar completado'}
+          </Button>
+        ) : (
+          <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
+        )}
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- add login prompts on `CourseCard` when no user is logged in
- show "Mis cursos" and filter available courses on the Courses page
- hide video content and completion button in modules when not logged
- show module descriptions in course detail and prompt login to enroll

## Testing
- `npm install`
- `npx eslint .`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856fc47f6e0832f8d8da249371e2be1