### PR TITLE
Add inscription button for logged users

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -9,7 +9,11 @@ interface Props {
 }
 
 export default function CourseCard({ id, title, duration, level }: Props) {
-  const isLogged = useAuthStore(state => state.isLogged)
+  const { isLogged, enrolledCourses } = useAuthStore(state => ({
+    isLogged: state.isLogged,
+    enrolledCourses: state.enrolledCourses,
+  }))
+  const isEnrolled = enrolledCourses.some(c => c.id === id)
 
   return (
     <div className="border p-4 rounded shadow hover:shadow-lg flex flex-col gap-2 w-full">
@@ -18,13 +22,22 @@ export default function CourseCard({ id, title, duration, level }: Props) {
         <p>Duración: {duration}</p>
         <p>Nivel: {level}</p>
       </Link>
-      {!isLogged && (
+      {!isLogged ? (
         <Link
           to="/login"
           className="mt-2 px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
         >
           Inicia sesión para inscribirte
         </Link>
+      ) : (
+        !isEnrolled && (
+          <Link
+            to={`/cursos/${id}/inscripcion`}
+            className="mt-2 px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
+          >
+            Inscribirse
+          </Link>
+        )
       )}
     </div>
   )

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -22,7 +22,7 @@ export default function CourseDetail() {
             <img
               src={course.image}
               alt={course.title}
-              className="w-full h-auto object-cover sm:max-h-[200px] rounded overflow-hidden"
+              className="w-full max-h-[200px] object-contain rounded overflow-hidden"
             />
             <h1 className="text-3xl font-bold">{course.title}</h1>
             <p>{course.description}</p>


### PR DESCRIPTION
## Summary
- show an "Inscribirse" button on each course card for logged users who are not enrolled
- display course images without cropping

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68570582b788832f97ba7c6f72f256a3