### PR TITLE
Fix infinite re-renders on courses page

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -9,10 +9,8 @@ interface Props {
 }
 
 export default function CourseCard({ id, title, duration, level }: Props) {
-  const { isLogged, enrolledCourses } = useAuthStore(state => ({
-    isLogged: state.isLogged,
-    enrolledCourses: state.enrolledCourses,
-  }))
+  const isLogged = useAuthStore(state => state.isLogged)
+  const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const isEnrolled = enrolledCourses.some(c => c.id === id)
 
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,7 +5,9 @@ import { useAuthStore } from '../store/auth'
 
 export default function Navbar() {
   const navigate = useNavigate()
-  const { isLogged, user, logout } = useAuthStore()
+  const isLogged = useAuthStore(state => state.isLogged)
+  const user = useAuthStore(state => state.user)
+  const logout = useAuthStore(state => state.logout)
   const [open, setOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const exampleUser = { name: 'Mariana' }

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -5,7 +5,8 @@ import CourseCard from '../components/CourseCard'
 import { useAuthStore } from '../store/auth'
 
 export default function Courses() {
-  const { isLogged, enrolledCourses } = useAuthStore()
+  const isLogged = useAuthStore(state => state.isLogged)
+  const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const availableCourses = courses.filter(
     c => !enrolledCourses.some(e => e.id === c.id),
   )

--- a/src/pages/InscriptionForm.tsx
+++ b/src/pages/InscriptionForm.tsx
@@ -9,7 +9,9 @@ import { courses } from '../data/courses'
 export default function InscriptionForm() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const { isLogged, enroll, enrolledCourses } = useAuthStore()
+  const isLogged = useAuthStore(state => state.isLogged)
+  const enroll = useAuthStore(state => state.enroll)
+  const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,7 +5,7 @@ import Button from '../components/Button'
 import { useAuthStore } from '../store/auth'
 
 export default function Profile() {
-  const { user } = useAuthStore()
+  const user = useAuthStore(state => state.user)
   const [name, setName] = useState((user as { name?: string } | null)?.name || '')
   const [email, setEmail] = useState((user as { email?: string } | null)?.email || '')
 


### PR DESCRIPTION
## Summary
- stabilize zustand usage by selecting specific auth store fields

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685715565c48832fb0071fb1425da8ca