### PR TITLE
Improve course cards and module access control

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -6,9 +6,10 @@ interface Props {
   title: string
   duration: string
   level: string
+  image: string
 }
 
-export default function CourseCard({ id, title, duration, level }: Props) {
+export default function CourseCard({ id, title, duration, level, image }: Props) {
   const isLogged = useAuthStore(state => state.isLogged)
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const isEnrolled = enrolledCourses.some(c => c.id === id)
@@ -16,6 +17,7 @@ export default function CourseCard({ id, title, duration, level }: Props) {
   return (
     <div className="border p-4 rounded shadow hover:shadow-lg flex flex-col gap-2 w-full">
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
+        <img src={image} alt={title} className="w-full h-24 object-cover rounded" />
         <h2 className="text-xl font-semibold">{title}</h2>
         <p>Duración: {duration}</p>
         <p>Nivel: {level}</p>

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -31,6 +31,7 @@ export default function Courses() {
                       title={info?.title ?? course.title}
                       duration={info?.duration ?? ''}
                       level={info?.level ?? ''}
+                      image={info?.image ?? ''}
                     />
                   )
                 })}
@@ -51,6 +52,7 @@ export default function Courses() {
                 title={course.title}
                 duration={course.duration}
                 level={course.level}
+                image={course.image}
               />
             ))}
           </div>

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -14,6 +14,7 @@ export default function Module() {
   const progress = useAuthStore(state =>
     state.enrolledCourses.find(c => c.id === id),
   )
+  const isEnrolled = !!progress
   const setCurrentCourse = useAuthStore(state => state.setCurrentCourse)
   const course = courses.find(c => c.id === id)
   const module = course?.modules.find(m => m.id === moduleId)
@@ -39,13 +40,15 @@ export default function Module() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
+      <main className="container mx-auto flex-grow p-4 flex flex-col items-center space-y-4">
         {course && module ? (
           <>
-            <h1 className="text-3xl font-bold">{course.title} - {module.title}</h1>
-            <p>{module.description}</p>
-            {isLogged ? (
-              <>
+            <h1 className="text-3xl font-bold text-center">
+              {course.title} - {module.title}
+            </h1>
+            <p className="text-center">{module.description}</p>
+            {isLogged && isEnrolled ? (
+              <div className="border p-4 rounded shadow w-full max-w-md text-center">
                 <a
                   href={module.videoUrl}
                   className="text-blue-600 underline"
@@ -54,16 +57,19 @@ export default function Module() {
                 >
                   Ver video
                 </a>
-              </>
+              </div>
+            ) : isLogged ? (
+              <p className="italic text-center">Inscríbete para ver el contenido de este módulo.</p>
             ) : (
-              <p className="italic">Inicia sesión para ver el contenido de este módulo.</p>
+              <p className="italic text-center">Inicia sesión para ver el contenido de este módulo.</p>
             )}
           </>
         ) : (
           <p>Módulo no encontrado</p>
         )}
-        {isLogged ? (
+        {isLogged && isEnrolled ? (
           <Button
+            className="mx-auto"
             onClick={handleComplete}
             disabled={progress ? progress.completed >= progress.total : false}
           >
@@ -71,7 +77,7 @@ export default function Module() {
               ? 'Curso completado'
               : 'Marcar completado'}
           </Button>
-        ) : (
+        ) : isLogged ? null : (
           <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
         )}
       </main>


### PR DESCRIPTION
## Summary
- show course cover images on each card
- enforce enrollment to watch videos and mark modules as completed
- center module content and action button

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68571a994544832fb38b75aa67c01329