### PR TITLE
Add local cache persistence and module gating

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ export default function Navbar() {
   const isLogged = useAuthStore(state => state.isLogged)
   const user = useAuthStore(state => state.user)
   const logout = useAuthStore(state => state.logout)
+  const clearCache = useAuthStore(state => state.clearCache)
   const [open, setOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const exampleUser = { name: 'Mariana' }
@@ -89,6 +90,17 @@ export default function Navbar() {
                     className="text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
                   >
                     Cerrar sesión
+                  </button>
+                  <button
+                    onClick={() => {
+                      clearCache()
+                      navigate('/')
+                      setOpen(false)
+                      setDropdownOpen(false)
+                    }}
+                    className="text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    Borrar caché
                   </button>
                 </div>
               )}

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -32,18 +32,24 @@ export default function CourseDetail() {
               <span className="px-3 py-1 bg-gray-200 rounded">Módulos: {course.modules.length}</span>
             </div>
             <ul className="list-disc pl-6 space-y-2">
-              {course.modules.map(m => (
-                <li key={m.id} className="space-y-1">
-                  {isLogged ? (
-                    <Link to={`/cursos/${id}/modulo/${m.id}`} className="text-blue-600 underline">
-                      {m.title}
-                    </Link>
-                  ) : (
-                    <span className="font-semibold">{m.title}</span>
-                  )}
-                  <p className="ml-4 text-sm text-gray-600">{m.description}</p>
-                </li>
-              ))}
+              {course.modules.map(m => {
+                const allowed = progress ? parseInt(m.id) <= progress.completed + 1 : false
+                return (
+                  <li key={m.id} className="space-y-1">
+                    {isLogged && allowed ? (
+                      <Link
+                        to={`/cursos/${id}/modulo/${m.id}`}
+                        className="text-blue-600 underline"
+                      >
+                        {m.title}
+                      </Link>
+                    ) : (
+                      <span className="font-semibold text-gray-500">{m.title}</span>
+                    )}
+                    <p className="ml-4 text-sm text-gray-600">{m.description}</p>
+                  </li>
+                )
+              })}
             </ul>
           {progress && (
             <p className="font-semibold">

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -15,6 +15,9 @@ export default function Module() {
     state.enrolledCourses.find(c => c.id === id),
   )
   const isEnrolled = !!progress
+  const moduleNumber = parseInt(moduleId ?? '0', 10)
+  const canAccess =
+    !moduleId || !isEnrolled || progress.completed >= moduleNumber - 1
   const setCurrentCourse = useAuthStore(state => state.setCurrentCourse)
   const course = courses.find(c => c.id === id)
   const module = course?.modules.find(m => m.id === moduleId)
@@ -26,6 +29,9 @@ export default function Module() {
   const handleComplete = () => {
     if (!isLogged) {
       navigate('/login')
+      return
+    }
+    if (!canAccess) {
       return
     }
     if (!progress || progress.completed < progress.total) {
@@ -47,7 +53,7 @@ export default function Module() {
               {course.title} - {module.title}
             </h1>
             <p className="text-center">{module.description}</p>
-            {isLogged && isEnrolled ? (
+            {isLogged && isEnrolled && canAccess ? (
               <div className="border p-4 rounded shadow w-full max-w-md text-center">
                 <a
                   href={module.videoUrl}
@@ -58,6 +64,11 @@ export default function Module() {
                   Ver video
                 </a>
               </div>
+            ) : isLogged && isEnrolled && !canAccess ? (
+              <p className="italic text-center">
+                Primero debes completar el módulo{' '}
+                {course?.modules.find(m => m.id === String(moduleNumber - 1))?.title}
+              </p>
             ) : isLogged ? (
               <p className="italic text-center">Inscríbete para ver el contenido de este módulo.</p>
             ) : (
@@ -71,7 +82,9 @@ export default function Module() {
           <Button
             className="mx-auto"
             onClick={handleComplete}
-            disabled={progress ? progress.completed >= progress.total : false}
+            disabled={
+              !canAccess || (progress ? progress.completed >= progress.total : false)
+            }
           >
             {progress && progress.completed >= progress.total
               ? 'Curso completado'

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -10,44 +10,67 @@ export interface Course {
 export interface AuthState {
   isLogged: boolean
   user: Record<string, unknown> | null
+  token: string | null
   enrolledCourses: Course[]
   currentCourseId: string | null
   login: (user: Record<string, unknown>) => void
   logout: () => void
+  clearCache: () => void
   enroll: (course: Course) => void
   completeModule: (courseId: string) => void
   setCurrentCourse: (courseId: string | null) => void
 }
 
-const useAuthStore = create<AuthState>((set) => {
-  const stored = localStorage.getItem('user')
-  const initialUser = stored ? JSON.parse(stored) : null
+const useAuthStore = create<AuthState>(set => {
+  const storedUser = localStorage.getItem('user')
+  const initialUser = storedUser ? JSON.parse(storedUser) : null
+  const storedToken = localStorage.getItem('token')
+  const storedCourses = localStorage.getItem('enrolledCourses')
+  const initialCourses: Course[] = storedCourses ? JSON.parse(storedCourses) : []
   const storedCourse = localStorage.getItem('currentCourseId')
 
+  const persistCourses = (courses: Course[]) =>
+    localStorage.setItem('enrolledCourses', JSON.stringify(courses))
+
   return {
-    isLogged: !!initialUser,
+    isLogged: !!initialUser && !!storedToken,
     user: initialUser,
-    enrolledCourses: [],
+    token: storedToken,
+    enrolledCourses: initialCourses,
     currentCourseId: storedCourse,
-    login: (user) => {
+    login: user => {
+      const token = `token-${Date.now()}`
       localStorage.setItem('user', JSON.stringify(user))
-      set({ isLogged: true, user })
+      localStorage.setItem('token', token)
+      set({ isLogged: true, user, token })
     },
     logout: () => {
       localStorage.removeItem('user')
+      localStorage.removeItem('token')
       localStorage.removeItem('currentCourseId')
-      set({ isLogged: false, user: null, enrolledCourses: [], currentCourseId: null })
+      localStorage.removeItem('enrolledCourses')
+      set({ isLogged: false, user: null, token: null, enrolledCourses: [], currentCourseId: null })
+    },
+    clearCache: () => {
+      localStorage.clear()
+      set({ isLogged: false, user: null, token: null, enrolledCourses: [], currentCourseId: null })
     },
     enroll: course =>
-      set(state => ({ enrolledCourses: [...state.enrolledCourses, course] })),
+      set(state => {
+        const updated = [...state.enrolledCourses, course]
+        persistCourses(updated)
+        return { enrolledCourses: updated }
+      }),
     completeModule: courseId =>
-      set(state => ({
-        enrolledCourses: state.enrolledCourses.map(c =>
+      set(state => {
+        const updated = state.enrolledCourses.map(c =>
           c.id === courseId && c.completed < c.total
             ? { ...c, completed: c.completed + 1 }
             : c,
-        ),
-      })),
+        )
+        persistCourses(updated)
+        return { enrolledCourses: updated }
+      }),
     setCurrentCourse: courseId => {
       if (courseId) {
         localStorage.setItem('currentCourseId', courseId)


### PR DESCRIPTION
## Summary
- persist enrolled courses and auth token in local storage
- provide a clear cache option in the navbar dropdown
- block module access until the previous one is completed
- disable inaccessible modules in course detail

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68571da958d0832fa599e78da419f4b2