### PR TITLE
Improve course navigation feedback

### DIFF
--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -34,30 +34,39 @@ export default function CourseDetail() {
             <ul className="list-disc pl-6 space-y-2">
               {course.modules.map(m => {
                 const allowed = progress ? parseInt(m.id) <= progress.completed + 1 : false
+                const isCurrent = progress ? parseInt(m.id) === progress.completed + 1 : false
                 return (
-                  <li key={m.id} className="space-y-1">
+                  <li
+                    key={m.id}
+                    className={`space-y-1 ${isCurrent ? 'bg-blue-50 border-l-4 border-blue-400 pl-2' : ''}`}
+                  >
                     {isLogged && allowed ? (
                       <Link
                         to={`/cursos/${id}/modulo/${m.id}`}
-                        className="text-blue-600 underline"
+                        className={`${isCurrent ? 'text-blue-700 font-semibold underline' : 'text-blue-600 underline'}`}
                       >
                         {m.title}
                       </Link>
                     ) : (
-                      <span className="font-semibold text-gray-500">{m.title}</span>
+                      <span className={`font-semibold ${isCurrent ? 'text-blue-700' : 'text-gray-500'}`}>{m.title}</span>
                     )}
                     <p className="ml-4 text-sm text-gray-600">{m.description}</p>
                   </li>
                 )
               })}
             </ul>
-          {progress && (
-            <p className="font-semibold">
-              {progress.completed >= progress.total
-                ? `Curso finalizado - Nota: ${progress.grade ?? '-'}`
-                : `${Math.round((progress.completed / progress.total) * 100)}% completado`}
-            </p>
-          )}
+            {progress && (
+              <p className="font-semibold">
+                {progress.completed >= progress.total
+                  ? `Curso finalizado - Nota: ${progress.grade ?? '-'}`
+                  : `${Math.round((progress.completed / progress.total) * 100)}% completado`}
+              </p>
+            )}
+            {progress && progress.completed >= progress.total && (
+              <Button onClick={() => navigate(`/cursos/${id}/examen-final`)}>
+                Ir al examen final
+              </Button>
+            )}
         </>
         ) : (
           <p>Curso no encontrado</p>

--- a/src/pages/InscriptionForm.tsx
+++ b/src/pages/InscriptionForm.tsx
@@ -32,7 +32,7 @@ export default function InscriptionForm() {
       title: course?.title ?? `Curso ${id}`,
       completed: 0,
       total: course?.modules.length ?? 0,
-      grade: null,
+      grade: undefined,
     })
     navigate('/inscripcion-exitosa', { state: { courseTitle: course?.title } })
   }

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -18,6 +18,8 @@ export default function Module() {
   const moduleNumber = parseInt(moduleId ?? '0', 10)
   const canAccess =
     !moduleId || !isEnrolled || progress.completed >= moduleNumber - 1
+  const isCompleted =
+    isLogged && isEnrolled && progress.completed >= moduleNumber
   const setCurrentCourse = useAuthStore(state => state.setCurrentCourse)
   const course = courses.find(c => c.id === id)
   const module = course?.modules.find(m => m.id === moduleId)
@@ -81,17 +83,19 @@ export default function Module() {
           <p>Módulo no encontrado</p>
         )}
         {isLogged && isEnrolled ? (
-          <Button
-            className="mx-auto"
-            onClick={handleComplete}
-            disabled={
-              !canAccess || (progress ? progress.completed >= progress.total : false)
-            }
-          >
-            {progress && progress.completed >= progress.total
-              ? 'Curso completado'
-              : 'Marcar completado'}
-          </Button>
+          isCompleted ? (
+            <p className="text-center italic">Ya has completado este módulo. Puedes volver a ver el video.</p>
+          ) : (
+            <Button
+              className="mx-auto"
+              onClick={handleComplete}
+              disabled={!canAccess || (progress ? progress.completed >= progress.total : false)}
+            >
+              {progress && progress.completed >= progress.total
+                ? 'Curso completado'
+                : 'Marcar completado'}
+            </Button>
+          )
         ) : isLogged ? null : (
           <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
         )}


### PR DESCRIPTION
## Summary
- indicate when a module was already completed
- highlight the next module to take
- expose final exam button once all modules are complete
- fix type error in inscription form

## Testing
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68572b86c704832fab67fee820a2fa9b