### PR TITLE
Improve course completion UI

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -18,15 +18,36 @@ export default function CourseCard({ id, title, duration, level, image }: Props)
   return (
     <div className="border p-4 rounded shadow hover:shadow-lg flex flex-col gap-2 w-full">
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
-        <img src={image} alt={title} className="w-full h-24 object-cover rounded" />
+        <img
+          src={image}
+          alt={title}
+          className="w-full h-48 object-cover rounded"
+        />
         <h2 className="text-xl font-semibold">{title}</h2>
         <p>Duración: {duration}</p>
         <p>Nivel: {level}</p>
         {isEnrolled && (
           <p className="text-sm mt-1">
-            {progress && progress.completed >= progress.total
-              ? `Curso finalizado - Nota: ${progress.grade ?? '-'}`
-              : `${Math.round((progress?.completed ?? 0) / (progress?.total ?? 1) * 100)}% completado`}
+            {progress && progress.completed >= progress.total ? (
+              <>
+                Curso finalizado - Nota: {progress.grade ?? '-'}{' '}
+                {progress.grade !== undefined && (
+                  <span
+                    className={`ml-1 px-2 py-0.5 rounded text-xs ${
+                      progress.grade >= 40
+                        ? 'bg-green-200 text-green-800'
+                        : 'bg-red-200 text-red-800'
+                    }`}
+                  >
+                    {progress.grade >= 40 ? 'Aprobado' : 'Desaprobado'}
+                  </span>
+                )}
+              </>
+            ) : (
+              `${Math.round(
+                ((progress?.completed ?? 0) / (progress?.total ?? 1)) * 100,
+              )}% completado`
+            )}
           </p>
         )}
       </Link>

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -57,12 +57,27 @@ export default function CourseDetail() {
             </ul>
             {progress && (
               <p className="font-semibold">
-                {progress.completed >= progress.total
-                  ? `Curso finalizado - Nota: ${progress.grade ?? '-'}`
-                  : `${Math.round((progress.completed / progress.total) * 100)}% completado`}
+                {progress.completed >= progress.total && progress.grade !== undefined ? (
+                  <>
+                    Has finalizado este curso con nota: {progress.grade}{' '}
+                    <span
+                      className={`ml-1 px-2 py-0.5 rounded text-xs ${
+                        progress.grade >= 40
+                          ? 'bg-green-200 text-green-800'
+                          : 'bg-red-200 text-red-800'
+                      }`}
+                    >
+                      {progress.grade >= 40 ? 'Aprobado' : 'Desaprobado'}
+                    </span>
+                  </>
+                ) : progress.completed >= progress.total ? (
+                  'Curso finalizado'
+                ) : (
+                  `${Math.round((progress.completed / progress.total) * 100)}% completado`
+                )}
               </p>
             )}
-            {progress && progress.completed >= progress.total && (
+            {progress && progress.completed >= progress.total && progress.grade === undefined && (
               <Button onClick={() => navigate(`/cursos/${id}/examen-final`)}>
                 Ir al examen final
               </Button>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ export default function Dashboard() {
                 <h2 className="text-2xl font-semibold">Cursos en curso</h2>
                 <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
                   {currentCourses.map(course => {
+                    const info = courses.find(c => c.id === course.id)
                     const completed = course.completed
                     const total = course.total
                     const remaining = total - completed
@@ -38,6 +39,13 @@ export default function Dashboard() {
                         key={course.id}
                         className="border p-4 rounded shadow flex flex-col items-center gap-2 w-full overflow-hidden"
                       >
+                        {info?.image && (
+                          <img
+                            src={info.image}
+                            alt={course.title}
+                            className="w-full h-48 object-cover rounded"
+                          />
+                        )}
                         <h2 className="text-xl font-semibold text-center w-full">
                           {course.title}
                         </h2>
@@ -83,11 +91,29 @@ export default function Dashboard() {
                         key={course.id}
                         className="border p-4 rounded shadow flex flex-col gap-2 w-full"
                       >
+                        {info?.image && (
+                          <img
+                            src={info.image}
+                            alt={course.title}
+                            className="w-full h-48 object-cover rounded"
+                          />
+                        )}
                         <h2 className="text-xl font-semibold text-center w-full">
                           {course.title}
                         </h2>
                         <p className="text-center font-semibold">
-                          Nota: {course.grade ?? '-'}
+                          Nota: {course.grade ?? '-'}{' '}
+                          {course.grade !== undefined && (
+                            <span
+                              className={`ml-1 px-2 py-0.5 rounded text-xs ${
+                                course.grade >= 40
+                                  ? 'bg-green-200 text-green-800'
+                                  : 'bg-red-200 text-red-800'
+                              }`}
+                            >
+                              {course.grade >= 40 ? 'Aprobado' : 'Desaprobado'}
+                            </span>
+                          )}
                         </p>
                         <ul className="list-disc pl-6 text-sm flex-grow">
                           {info?.modules.map(m => (

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -11,7 +11,7 @@ export default function FinalExam() {
 
   const handleFinish = () => {
     if (id) {
-      const grade = Math.floor(Math.random() * 41) + 60
+      const grade = Math.floor(Math.random() * 101)
       finishCourse(id, grade)
     }
     navigate('/dashboard')


### PR DESCRIPTION
## Summary
- hide the final exam button after submitting exam
- display grade with pass/fail badge on course pages
- enlarge course cover images and show them on dashboard
- add approval status in dashboard and course cards
- generate random grades between 0 and 100

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685730f7c83c832f88869d3c368f9415