### PR TITLE
Add exam retake logic and dashboard links

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,5 +9,6 @@ export default function Button({ variant = 'primary', className = '', ...props }
   const styles = variant === 'primary'
     ? 'bg-blue-600 text-white hover:bg-blue-700'
     : 'bg-gray-300 text-gray-800 hover:bg-gray-400'
-  return <button className={`${base} ${styles} ${className}`} {...props} />
+  const disabledStyles = props.disabled ? 'opacity-50 cursor-not-allowed' : ''
+  return <button className={`${base} ${styles} ${disabledStyles} ${className}`} {...props} />
 }

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -12,6 +12,9 @@ export default function CourseDetail() {
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const course = courses.find(c => c.id === id)
   const progress = enrolledCourses.find(c => c.id === id)
+  const canRetake = progress?.nextExamDate
+    ? new Date(progress.nextExamDate) <= new Date()
+    : true
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -77,11 +80,24 @@ export default function CourseDetail() {
                 )}
               </p>
             )}
-            {progress && progress.completed >= progress.total && progress.grade === undefined && (
-              <Button onClick={() => navigate(`/cursos/${id}/examen-final`)}>
-                Ir al examen final
-              </Button>
-            )}
+            {progress &&
+              progress.completed >= progress.total &&
+              (progress.grade === undefined || progress.grade < 40) && (
+                <>
+                  {progress.grade !== undefined && progress.grade < 40 &&
+                    !canRetake && (
+                      <p className="text-sm text-red-600">
+                        Vas a poder volver a contestar el examen mañana.
+                      </p>
+                    )}
+                  <Button
+                    onClick={() => navigate(`/cursos/${id}/examen-final`)}
+                    disabled={progress.grade !== undefined && progress.grade < 40 && !canRetake}
+                  >
+                    Ir al examen final
+                  </Button>
+                </>
+              )}
         </>
         ) : (
           <p>Curso no encontrado</p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -66,14 +66,23 @@ export default function Dashboard() {
                         <p className="text-sm">
                           {course.completed} de {course.total} módulos
                         </p>
-                        <Button
-                          className="mt-auto"
-                          onClick={() =>
-                            navigate(`/cursos/${course.id}/modulo/${course.completed + 1}`)
-                          }
-                        >
-                          Continuar curso
-                        </Button>
+                        <div className="flex gap-2 mt-auto">
+                          <Button
+                            onClick={() =>
+                              navigate(`/cursos/${course.id}`)
+                            }
+                            variant="secondary"
+                          >
+                            Ver curso
+                          </Button>
+                          <Button
+                            onClick={() =>
+                              navigate(`/cursos/${course.id}/modulo/${course.completed + 1}`)
+                            }
+                          >
+                            Continuar curso
+                          </Button>
+                        </div>
                       </div>
                     )
                   })}
@@ -120,6 +129,12 @@ export default function Dashboard() {
                             <li key={m.id}>{m.title}</li>
                           ))}
                         </ul>
+                        <Button
+                          onClick={() => navigate(`/cursos/${course.id}`)}
+                          variant="secondary"
+                        >
+                          Ver curso
+                        </Button>
                       </div>
                     )
                   })}

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -8,6 +8,12 @@ export default function FinalExam() {
   const { id } = useParams()
   const navigate = useNavigate()
   const finishCourse = useAuthStore(state => state.finishCourse)
+  const progress = useAuthStore(state =>
+    state.enrolledCourses.find(c => c.id === id),
+  )
+  const canAttempt = progress?.nextExamDate
+    ? new Date(progress.nextExamDate) <= new Date()
+    : true
 
   const handleFinish = () => {
     if (id) {
@@ -22,7 +28,14 @@ export default function FinalExam() {
       <main className="container mx-auto flex-grow p-4 space-y-4">
         <h1 className="text-3xl font-bold">Examen final - Curso {id}</h1>
         <p>Completa las preguntas para finalizar el curso.</p>
-        <Button onClick={handleFinish}>Enviar respuestas</Button>
+        {!canAttempt && (
+          <p className="text-red-600">
+            Vas a poder volver a contestar el examen mañana.
+          </p>
+        )}
+        <Button onClick={handleFinish} disabled={!canAttempt}>
+          Enviar respuestas
+        </Button>
       </main>
       <Footer />
     </div>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -6,6 +6,8 @@ export interface Course {
   completed: number
   total: number
   grade?: number
+  /** ISO date string indicating when the user can retake the final exam */
+  nextExamDate?: string
 }
 
 export interface AuthState {
@@ -75,9 +77,16 @@ const useAuthStore = create<AuthState>(set => {
       }),
     finishCourse: (courseId, grade) =>
       set(state => {
-        const updated = state.enrolledCourses.map(c =>
-          c.id === courseId ? { ...c, grade } : c,
-        )
+        const updated = state.enrolledCourses.map(c => {
+          if (c.id !== courseId) return c
+          const tomorrow = new Date()
+          tomorrow.setDate(tomorrow.getDate() + 1)
+          return {
+            ...c,
+            grade,
+            nextExamDate: grade < 40 ? tomorrow.toISOString() : undefined,
+          }
+        })
         persistCourses(updated)
         return { enrolledCourses: updated }
       }),


### PR DESCRIPTION
## Summary
- allow retaking failed exams after one day
- show disabled button and message until retake available
- add navigation to course page from dashboard cards
- improve button component disabled style

## Testing
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857339b6b20832fa3fcfd9413845231