### PR TITLE
Add back buttons to course and module pages

### DIFF
--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -20,6 +20,7 @@ export default function CourseDetail() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 flex flex-col items-start gap-4">
+        <Button variant="secondary" onClick={() => navigate(-1)}>Volver atrás</Button>
         {course ? (
           <>
             <img

--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -51,6 +51,7 @@ export default function Module() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 flex flex-col items-center space-y-4">
+        <Button variant="secondary" onClick={() => navigate(-1)}>Volver atrás</Button>
         {course && module ? (
           <>
             <h1 className="text-3xl font-bold text-center">


### PR DESCRIPTION
## Summary
- add Back button at top of `CourseDetail`
- add Back button at top of `Module`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685735f99388832f844f84080ea8be83