### PR TITLE
Add Wireframes route

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Dentro de la carpeta `Wireframes` hay dos plantillas HTML estáticas que represe
 - `home-con-sesion.html` muestra la versión con la sesión iniciada.
 
 Ambas plantillas utilizan rectángulos y círculos grises para ilustrar la ubicación de los elementos.
+
+Además, la aplicación cuenta con una ruta `/wireframes` que lista enlaces a todas estas plantillas para poder visualizarlas de forma ordenada.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Profile from './pages/Profile'
 import Forum from './pages/Forum'
 import ErrorPage from './pages/ErrorPage'
 import NotFound from './pages/NotFound'
+import Wireframes from './pages/Wireframes'
 
 export default function App() {
   return (
@@ -27,6 +28,7 @@ export default function App() {
       <Route path="/dashboard" element={<Dashboard />} />
       <Route path="/perfil" element={<Profile />} />
       <Route path="/foro" element={<Forum />} />
+      <Route path="/wireframes" element={<Wireframes />} />
       <Route path="/error" element={<ErrorPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/pages/Wireframes.tsx
+++ b/src/pages/Wireframes.tsx
@@ -1,0 +1,45 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+const files = [
+  'home-sin-sesion.html',
+  'home-con-sesion.html',
+  'courses.html',
+  'course-detail.html',
+  'inscription-form.html',
+  'inscription-success.html',
+  'dashboard.html',
+  'module.html',
+  'final-exam.html',
+  'forum.html',
+  'login.html',
+  'profile.html',
+  'error-page.html',
+  'not-found.html',
+]
+
+export default function Wireframes() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Wireframes</h1>
+        <ul className="list-disc pl-5 space-y-1">
+          {files.map(file => (
+            <li key={file}>
+              <a
+                href={`/Wireframes/${file}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+              >
+                {file.replace('.html', '').replace(/-/g, ' ')}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a list of wireframe HTML mockups at `/wireframes`
- document this new route in the README

## Testing
- `npx eslint .`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_6859a00d54f8832f9115c9f14236a26a