### PR TITLE
Implement Nosotros page and rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Curso Webapp
+# Aula Digital Ciudadana
 
 Aplicación React creada con Vite y TypeScript. Incluye Tailwind CSS 3 configurado, React Router y un modo oscuro básico.
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Aula Digital Ciudadana</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Module from './pages/Module'
 import FinalExam from './pages/FinalExam'
 import Profile from './pages/Profile'
 import Forum from './pages/Forum'
+import Nosotros from './pages/Nosotros'
 import ErrorPage from './pages/ErrorPage'
 import NotFound from './pages/NotFound'
 import Wireframes from './pages/Wireframes'
@@ -28,6 +29,7 @@ export default function App() {
       <Route path="/dashboard" element={<Dashboard />} />
       <Route path="/perfil" element={<Profile />} />
       <Route path="/foro" element={<Forum />} />
+      <Route path="/nosotros" element={<Nosotros />} />
       <Route path="/wireframes" element={<Wireframes />} />
       <Route path="/error" element={<ErrorPage />} />
       <Route path="*" element={<NotFound />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
         <div>
           <img src="/vite.svg" alt="Logo" className="h-8 mb-2" />
           <p>
-            Cursos Webapp es una plataforma de formación en línea para que aprendas a tu propio ritmo.
+            Aula Digital Ciudadana es una plataforma de formación en línea para que aprendas a tu propio ritmo.
           </p>
         </div>
         <div>
@@ -36,7 +36,7 @@ export default function Footer() {
         </div>
       </div>
       <div className="text-center py-4 bg-gray-300 dark:bg-gray-900">
-        © 2024 Cursos Webapp
+        © 2025 Aula Digital Ciudadana
       </div>
     </footer>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -67,6 +67,13 @@ export default function Navbar() {
           Cursos
         </NavLink>
         <NavLink
+          to="/nosotros"
+          className={({ isActive }) => `block ${isActive ? 'font-semibold text-blue-600' : ''}`}
+          onClick={() => setOpen(false)}
+        >
+          Nosotros
+        </NavLink>
+        <NavLink
           to="/foro"
           className={({ isActive }) => `block ${isActive ? 'font-semibold text-blue-600' : ''}`}
           onClick={() => setOpen(false)}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,9 +11,9 @@ export default function Home() {
         <section className="container mx-auto flex flex-col-reverse md:flex-row items-center gap-8 p-8 bg-gradient-to-r from-blue-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 rounded-lg">
           <div className="flex flex-col items-start gap-4 md:w-1/2">
             <h1 className="text-4xl md:text-5xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Aprende y potencia tu carrera
+              Aula Digital Ciudadana
             </h1>
-            <p className="text-lg">Cursos online dictados por profesionales del desarrollo web.</p>
+            <p className="text-lg">Aprende y potencia tu carrera con cursos online dictados por profesionales del desarrollo web.</p>
             <Link to="/cursos">
               <Button variant="primary">Explorar cursos</Button>
             </Link>

--- a/src/pages/Nosotros.tsx
+++ b/src/pages/Nosotros.tsx
@@ -1,0 +1,15 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export default function Nosotros() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-4 p-4 text-center">
+        <h1 className="text-3xl font-bold">Nosotros</h1>
+        <p className="text-lg">Informaci\u00f3n sobre Aula Digital Ciudadana.</p>
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- rename project to Aula Digital Ciudadana
- update home hero title and footer branding
- update copyright year
- add Nosotros page and route
- show "Nosotros" in navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859aaf58278832fbe4af98d59b52e9e