### PR TITLE
Adjust dark mode visibility and logo sizes

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ export default function Footer() {
     <footer className="bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200 text-sm">
       <div className="container mx-auto px-4 py-8 grid gap-8 md:grid-cols-4">
         <div>
-          <img src="/logo.png" alt="Logo" className="h-8 mb-2" />
+          <img src="/logo.png" alt="Logo" className="h-16 w-48 mb-2" />
           <p>
             Aula Digital Ciudadana es una plataforma de formación en línea para que aprendas a tu propio ritmo.
           </p>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -38,9 +38,8 @@ export default function Navbar() {
           )}
         </button>
         <Link to="/" className="mx-auto" onClick={() => setOpen(false)}>
-          <img src="/logo.png" alt="Logo" className="h-8" />
+          <img src="/logo.png" alt="Logo" className="h-10 w-24" />
         </Link>
-        {!isLogged && <DarkModeToggle className="ml-auto" />}
       </div>
       <div
         className={`${open ? 'flex' : 'hidden'} sm:flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 border-t sm:border-none`}
@@ -50,7 +49,7 @@ export default function Navbar() {
           className="hidden sm:block mr-4"
           onClick={() => setOpen(false)}
         >
-          <img src="/logo.png" alt="Logo" className="h-8" />
+          <img src="/logo.png" alt="Logo" className="h-10 w-24" />
         </Link>
         <NavLink
           to="/"
@@ -142,7 +141,6 @@ export default function Navbar() {
               Ingresar
             </button>
           )}
-          {!isLogged && <DarkModeToggle className="hidden sm:block" />}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- hide dark mode toggle when user is not logged in
- enlarge navigation logo
- enlarge footer logo

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859b0363f10832fa2166bc303743f31