### PR TITLE
Actualizar vistas de cursos y detalles

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 ignoredBuiltDependencies:
   - esbuild
+packages:
+  - '.'

--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -7,9 +7,18 @@ interface Props {
   duration: string
   level: string
   image: string
+  /** Show user's progress info inside the card */
+  showProgress?: boolean
 }
 
-export default function CourseCard({ id, title, duration, level, image }: Props) {
+export default function CourseCard({
+  id,
+  title,
+  duration,
+  level,
+  image,
+  showProgress = true,
+}: Props) {
   const isLogged = useAuthStore(state => state.isLogged)
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const progress = enrolledCourses.find(c => c.id === id)
@@ -26,7 +35,7 @@ export default function CourseCard({ id, title, duration, level, image }: Props)
         <h2 className="text-xl font-semibold">{title}</h2>
         <p>Duración: {duration}</p>
         <p>Nivel: {level}</p>
-        {isEnrolled && (
+        {showProgress && isEnrolled && (
           <p className="text-sm mt-1">
             {progress && progress.completed >= progress.total ? (
               <>
@@ -51,23 +60,31 @@ export default function CourseCard({ id, title, duration, level, image }: Props)
           </p>
         )}
       </Link>
-      {!isLogged ? (
+      <div className="mt-2 flex gap-2">
         <Link
-          to="/login"
-          className="mt-2 px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
+          to={`/cursos/${id}`}
+          className="px-3 py-1 text-sm rounded bg-gray-300 text-gray-800 text-center hover:bg-gray-400"
         >
-          Inicia sesión para inscribirte
+          Ver más
         </Link>
-      ) : (
-        !isEnrolled && (
+        {!isLogged ? (
           <Link
-            to={`/cursos/${id}/inscripcion`}
-            className="mt-2 px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
+            to="/login"
+            className="px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
           >
-            Inscribirse
+            Inicia sesión para inscribirte
           </Link>
-        )
-      )}
+        ) : (
+          !isEnrolled && (
+            <Link
+              to={`/cursos/${id}/inscripcion`}
+              className="px-3 py-1 text-sm rounded bg-blue-600 text-white text-center hover:bg-blue-700"
+            >
+              Inscribirse
+            </Link>
+          )
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -20,7 +20,10 @@ export default function CourseDetail() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 flex flex-col items-start gap-4">
-        <Button variant="secondary" onClick={() => navigate(-1)}>Volver atrás</Button>
+        <nav className="text-sm">
+          <Link to="/cursos" className="text-blue-600 underline">Cursos</Link>
+          {course && <span> / {course.title}</span>}
+        </nav>
         {course ? (
           <>
             <img
@@ -28,17 +31,19 @@ export default function CourseDetail() {
               alt={course.title}
               className="w-full max-h-[200px] object-contain rounded overflow-hidden"
             />
-            <h1 className="text-3xl font-bold">{course.title}</h1>
-            <p>{course.description}</p>
+            <h1 className="text-4xl font-extrabold">{course.title}</h1>
+            <p className="text-lg">{course.description}</p>
             <div className="flex flex-wrap gap-2 text-sm">
               <span className="px-3 py-1 bg-gray-200 rounded">Nivel: {course.level}</span>
               <span className="px-3 py-1 bg-gray-200 rounded">Duración: {course.duration}</span>
               <span className="px-3 py-1 bg-gray-200 rounded">Módulos: {course.modules.length}</span>
             </div>
-            <ul className="list-disc pl-6 space-y-2">
-              {course.modules.map(m => {
+            <h2 className="text-2xl font-bold mt-4">Módulos</h2>
+            <ul className="pl-6 space-y-2">
+              {course.modules.map((m, i) => {
                 const allowed = progress ? parseInt(m.id) <= progress.completed + 1 : false
                 const isCurrent = progress ? parseInt(m.id) === progress.completed + 1 : false
+                const title = `Módulo ${i + 1}: ${m.title}`
                 return (
                   <li
                     key={m.id}
@@ -49,10 +54,10 @@ export default function CourseDetail() {
                         to={`/cursos/${id}/modulo/${m.id}`}
                         className={`${isCurrent ? 'text-blue-700 font-semibold underline' : 'text-blue-600 underline'}`}
                       >
-                        {m.title}
+                        {title}
                       </Link>
                     ) : (
-                      <span className={`font-semibold ${isCurrent ? 'text-blue-700' : 'text-gray-500'}`}>{m.title}</span>
+                      <span className={`font-semibold ${isCurrent ? 'text-blue-700' : 'text-gray-500'}`}>{title}</span>
                     )}
                     <p className="ml-4 text-sm text-gray-600">{m.description}</p>
                   </li>
@@ -104,25 +109,32 @@ export default function CourseDetail() {
           <p>Curso no encontrado</p>
         )}
         {(!progress || progress.completed < progress.total) && (
-          <Button
-            onClick={() => {
-              if (!progress) {
-                if (!isLogged) {
-                  navigate('/login')
+          <>
+            {!progress && (
+              <p className="font-semibold">
+                ¿Listo para comenzar? Inscríbete al curso para acceder a todos los módulos.
+              </p>
+            )}
+            <Button
+              onClick={() => {
+                if (!progress) {
+                  if (!isLogged) {
+                    navigate('/login')
+                  } else {
+                    navigate(`/cursos/${id}/inscripcion`)
+                  }
                 } else {
-                  navigate(`/cursos/${id}/inscripcion`)
+                  navigate(`/cursos/${id}/modulo/${progress.completed + 1}`)
                 }
-              } else {
-                navigate(`/cursos/${id}/modulo/${progress.completed + 1}`)
-              }
-            }}
-          >
-            {progress
-              ? `Continuar curso (${Math.round((progress.completed / progress.total) * 100)}%)`
-              : isLogged
-                ? 'Inscribirme'
-                : 'Inicia sesión para inscribirte'}
-          </Button>
+              }}
+            >
+              {progress
+                ? `Continuar curso (${Math.round((progress.completed / progress.total) * 100)}%)`
+                : isLogged
+                  ? 'Inscribirme'
+                  : 'Inicia sesión para inscribirte'}
+            </Button>
+          </>
         )}
       </main>
       <Footer />

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -17,11 +17,11 @@ export default function Courses() {
       <main className="container mx-auto flex-grow p-4 space-y-6">
         {isLogged && (
           <div className="space-y-4">
-            <h1 className="text-3xl font-bold">Mis cursos</h1>
+            <h1 className="text-3xl font-bold">Actualmente cursando</h1>
             {enrolledCourses.length === 0 ? (
               <p>Aún no estás inscrito en ningún curso.</p>
             ) : (
-              <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+              <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
                 {enrolledCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -44,7 +44,7 @@ export default function Courses() {
           <h1 className="text-3xl font-bold">
             {isLogged ? 'Todos los cursos' : 'Cursos disponibles'}
           </h1>
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
             {(isLogged ? availableCourses : courses).map(course => (
               <CourseCard
                 key={course.id}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -81,6 +81,7 @@ export default function Home() {
                   duration={course.duration}
                   level={course.level}
                   image={course.image}
+                  showProgress={false}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- allow hiding progress info from `CourseCard`
- add "Ver más" button to course cards
- show course cards without progress on home
- rename "Mis cursos" section to "Actualmente cursando"
- increase spacing between course cards
- show breadcrumb and improved details on course view
- add modules numbering and signup invitation
- fix pnpm workspace config for linting

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6859c2e9e0d8832f86bbb375a1e63d1e