### PR TITLE
Add course filters and back button

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -9,6 +9,7 @@ export interface CourseInfo {
   id: string
   title: string
   description: string
+  category: string
   image: string
   duration: string
   level: string
@@ -21,6 +22,7 @@ export const courses: CourseInfo[] = [
     title: 'HTML y CSS desde cero',
     description:
       'Aprende a construir paginas web modernas con HTML5 y CSS3 paso a paso.',
+    category: 'Frontend',
     image: '/images/course-html-css.png',
     duration: '4 semanas',
     level: 'Principiante',
@@ -66,6 +68,7 @@ export const courses: CourseInfo[] = [
     title: 'JavaScript desde cero',
     description:
       'Domina los fundamentos del lenguaje que impulsa la web moderna.',
+    category: 'Programación',
     image: '/images/course-js.png',
     duration: '5 semanas',
     level: 'Principiante',
@@ -116,6 +119,7 @@ export const courses: CourseInfo[] = [
     id: 'react-principiantes',
     title: 'React para principiantes',
     description: 'Crea interfaces interactivas con la librería más popular.',
+    category: 'Frontend',
     image: '/images/course-react.png',
     duration: '6 semanas',
     level: 'Intermedio',
@@ -156,6 +160,7 @@ export const courses: CourseInfo[] = [
     id: 'node-express',
     title: 'Node.js y Express',
     description: 'Construye servidores y APIs con JavaScript del lado del servidor.',
+    category: 'Backend',
     image: '/images/course-node.png',
     duration: '5 semanas',
     level: 'Intermedio',
@@ -196,6 +201,7 @@ export const courses: CourseInfo[] = [
     id: 'typescript-avanzado',
     title: 'TypeScript avanzado',
     description: 'Lleva tu código JavaScript al siguiente nivel con tipado fuerte.',
+    category: 'Programación',
     image: '/images/course-ts.png',
     duration: '6 semanas',
     level: 'Avanzado',
@@ -248,6 +254,7 @@ export const courses: CourseInfo[] = [
     id: 'mern-fullstack',
     title: 'Desarrollo Fullstack con MERN',
     description: 'Aprende a crear aplicaciones completas con Mongo, Express, React y Node.',
+    category: 'Fullstack',
     image: '/images/course-mern.png',
     duration: '8 semanas',
     level: 'Avanzado',
@@ -300,6 +307,7 @@ export const courses: CourseInfo[] = [
     id: 'testing-jest',
     title: 'Testing con Jest',
     description: 'Garantiza la calidad de tus aplicaciones con pruebas unitarias y de integración.',
+    category: 'Testing',
     image: '/images/course-jest.png',
     duration: '4 semanas',
     level: 'Intermedio',
@@ -340,6 +348,7 @@ export const courses: CourseInfo[] = [
     id: 'react-native',
     title: 'Aplicaciones móviles con React Native',
     description: 'Desarrolla apps nativas para iOS y Android usando JavaScript.',
+    category: 'Mobile',
     image: '/images/course-react-native.png',
     duration: '7 semanas',
     level: 'Intermedio',

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -20,7 +20,12 @@ export default function CourseDetail() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="container mx-auto flex-grow p-4 flex flex-col items-start gap-4">
-        <nav className="text-sm">
+        <nav className="text-sm flex items-center gap-2">
+          <button onClick={() => navigate(-1)} aria-label="Volver" className="p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+          </button>
           <Link to="/cursos" className="text-blue-600 underline">Cursos</Link>
           {course && <span> / {course.title}</span>}
         </nav>

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -3,12 +3,25 @@ import Footer from '../components/Footer'
 import { courses } from '../data/courses'
 import CourseCard from '../components/CourseCard'
 import { useAuthStore } from '../store/auth'
+import { useState } from 'react'
 
 export default function Courses() {
   const isLogged = useAuthStore(state => state.isLogged)
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const availableCourses = courses.filter(
     c => !enrolledCourses.some(e => e.id === c.id),
+  )
+  const categories = Array.from(new Set(courses.map(c => c.category)))
+  const levels = Array.from(new Set(courses.map(c => c.level)))
+  const durations = Array.from(new Set(courses.map(c => c.duration)))
+  const [category, setCategory] = useState('Todos')
+  const [level, setLevel] = useState('Todos')
+  const [duration, setDuration] = useState('Todas')
+  const filteredCourses = (isLogged ? availableCourses : courses).filter(
+    c =>
+      (category === 'Todos' || c.category === category) &&
+      (level === 'Todos' || c.level === level) &&
+      (duration === 'Todas' || c.duration === duration),
   )
 
   return (
@@ -44,8 +57,46 @@ export default function Courses() {
           <h1 className="text-3xl font-bold">
             {isLogged ? 'Todos los cursos' : 'Cursos disponibles'}
           </h1>
+          <div className="flex flex-wrap gap-4">
+            <select
+              className="border p-2 rounded"
+              value={category}
+              onChange={e => setCategory(e.target.value)}
+            >
+              <option value="Todos">Todas las categorías</option>
+              {categories.map(cat => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+            <select
+              className="border p-2 rounded"
+              value={level}
+              onChange={e => setLevel(e.target.value)}
+            >
+              <option value="Todos">Todos los niveles</option>
+              {levels.map(l => (
+                <option key={l} value={l}>
+                  {l}
+                </option>
+              ))}
+            </select>
+            <select
+              className="border p-2 rounded"
+              value={duration}
+              onChange={e => setDuration(e.target.value)}
+            >
+              <option value="Todas">Todas las duraciones</option>
+              {durations.map(d => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </div>
           <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-            {(isLogged ? availableCourses : courses).map(course => (
+            {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}
                 id={course.id}


### PR DESCRIPTION
## Summary
- categorize courses for filtering
- allow filtering on courses page by category, level and duration
- add back arrow on course detail navigation

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6859c69b09ac832fa1ef9f8e31590e0a