### PR TITLE
Update instructor layout and remove retake wait

### DIFF
--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -14,9 +14,6 @@ export default function CourseDetail() {
   const course = courses.find(c => c.id === id)
   const instructor = course ? getInstructorByCourse(course.id) : null
   const progress = enrolledCourses.find(c => c.id === id)
-  const canRetake = progress?.nextExamDate
-    ? new Date(progress.nextExamDate) <= new Date()
-    : true
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -56,7 +53,7 @@ export default function CourseDetail() {
           </p>
           <h2 className="text-2xl font-bold">Instructor</h2>
           {instructor && (
-            <div className="border rounded p-4 flex flex-col items-center gap-2 w-full sm:w-1/2">
+            <div className="border rounded p-4 flex flex-col items-center gap-2 w-full">
               <div className="w-24 h-24 rounded-full bg-gray-300 overflow-hidden flex items-center justify-center">
                 <img
                   src={instructor.avatar}
@@ -92,16 +89,14 @@ export default function CourseDetail() {
                     style={{ width: `${Math.min(100, Math.round((progress.completed / progress.total) * 100))}%` }}
                   />
                 </div>
-                {progress.completed >= progress.total ? (
-                  progress.grade === undefined ? (
+                {progress.completed >= progress.total &&
+                  (progress.grade === undefined || progress.grade < 40) ? (
                     <Button
                       onClick={() => navigate(`/cursos/${id}/examen-final`)}
-                      disabled={progress.grade !== undefined && progress.grade < 40 && !canRetake}
                     >
                       Contestar evaluación
                     </Button>
-                  ) : null
-                ) : (
+                  ) : progress.completed >= progress.total ? null : (
                   <Button onClick={() => navigate(`/cursos/${id}/modulo/${progress.completed + 1}`)}>Seguir</Button>
                 )}
               </div>
@@ -152,6 +147,11 @@ export default function CourseDetail() {
                       </span>
                     )}
                     <p className="text-sm text-gray-600">{m.description}</p>
+                    {completed && (
+                      <p className="text-xs italic text-gray-500">
+                        Haz clic para verlo nuevamente
+                      </p>
+                    )}
                   </li>
                 )
               })}

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -8,12 +8,6 @@ export default function FinalExam() {
   const { id } = useParams()
   const navigate = useNavigate()
   const finishCourse = useAuthStore(state => state.finishCourse)
-  const progress = useAuthStore(state =>
-    state.enrolledCourses.find(c => c.id === id),
-  )
-  const canAttempt = progress?.nextExamDate
-    ? new Date(progress.nextExamDate) <= new Date()
-    : true
 
   const handleFinish = () => {
     if (id) {
@@ -28,12 +22,7 @@ export default function FinalExam() {
       <main className="container mx-auto flex-grow p-4 space-y-4">
         <h1 className="text-3xl font-bold">Examen final - Curso {id}</h1>
         <p>Completa las preguntas para finalizar el curso.</p>
-        {!canAttempt && (
-          <p className="text-red-600">
-            Vas a poder volver a contestar el examen mañana.
-          </p>
-        )}
-        <Button onClick={handleFinish} disabled={!canAttempt}>
+        <Button onClick={handleFinish}>
           Enviar respuestas
         </Button>
       </main>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -6,8 +6,6 @@ export interface Course {
   completed: number
   total: number
   grade?: number
-  /** ISO date string indicating when the user can retake the final exam */
-  nextExamDate?: string
 }
 
 export interface AuthState {
@@ -72,16 +70,9 @@ const useAuthStore = create<AuthState>(set => {
       }),
     finishCourse: (courseId, grade) =>
       set(state => {
-        const updated = state.enrolledCourses.map(c => {
-          if (c.id !== courseId) return c
-          const tomorrow = new Date()
-          tomorrow.setDate(tomorrow.getDate() + 1)
-          return {
-            ...c,
-            grade,
-            nextExamDate: grade < 40 ? tomorrow.toISOString() : undefined,
-          }
-        })
+        const updated = state.enrolledCourses.map(c =>
+          c.id === courseId ? { ...c, grade } : c,
+        )
         persistCourses(updated)
         return { enrolledCourses: updated }
       }),


### PR DESCRIPTION
## Summary
- remove exam retake waiting logic
- allow exam retakes without delay
- make instructor card full width
- allow retaking final exam whenever the grade is under 40
- show hint to rewatch completed modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a004c7330832f94a603606bc0c066