### PR TITLE
Implement exam attempt restrictions and progress bar

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -14,6 +14,7 @@ export interface CourseInfo {
   duration: string
   level: string
   modules: ModuleInfo[]
+  maxAttempts: number
 }
 
 export const courses: CourseInfo[] = [
@@ -26,6 +27,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-html-css.png',
     duration: '4 semanas',
     level: 'Principiante',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -72,6 +74,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-js.png',
     duration: '5 semanas',
     level: 'Principiante',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -123,6 +126,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react.png',
     duration: '6 semanas',
     level: 'Intermedio',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -164,6 +168,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-node.png',
     duration: '5 semanas',
     level: 'Intermedio',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -205,6 +210,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-ts.png',
     duration: '6 semanas',
     level: 'Avanzado',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -258,6 +264,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-mern.png',
     duration: '8 semanas',
     level: 'Avanzado',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -311,6 +318,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-jest.png',
     duration: '4 semanas',
     level: 'Intermedio',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',
@@ -352,6 +360,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react-native.png',
     duration: '7 semanas',
     level: 'Intermedio',
+    maxAttempts: 3,
     modules: [
       {
         id: '1',

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -8,6 +8,13 @@ export default function FinalExam() {
   const { id } = useParams()
   const navigate = useNavigate()
   const finishCourse = useAuthStore(state => state.finishCourse)
+  const enrolled = useAuthStore(state => state.enrolledCourses)
+  const progress = enrolled.find(c => c.id === id)
+  const canRetakeExam = progress
+    ? (!progress.lastAttempt ||
+        Date.now() - progress.lastAttempt >= 24 * 60 * 60 * 1000) &&
+      progress.attempts < progress.maxAttempts
+    : false
 
   const handleFinish = () => {
     if (id) {
@@ -21,10 +28,14 @@ export default function FinalExam() {
       <Navbar />
       <main className="container mx-auto flex-grow p-4 space-y-4">
         <h1 className="text-3xl font-bold">Examen final - Curso {id}</h1>
-        <p>Completa las preguntas para finalizar el curso.</p>
-        <Button onClick={handleFinish}>
-          Enviar respuestas
-        </Button>
+        {canRetakeExam ? (
+          <>
+            <p>Completa las preguntas para finalizar el curso.</p>
+            <Button onClick={handleFinish}>Enviar respuestas</Button>
+          </>
+        ) : (
+          <p className="text-red-600">Aún no puedes realizar este examen.</p>
+        )}
       </main>
       <Footer />
     </div>

--- a/src/pages/InscriptionForm.tsx
+++ b/src/pages/InscriptionForm.tsx
@@ -33,6 +33,9 @@ export default function InscriptionForm() {
       completed: 0,
       total: course?.modules.length ?? 0,
       grade: undefined,
+      maxAttempts: course?.maxAttempts ?? 3,
+      attempts: 0,
+      lastAttempt: undefined,
     })
     navigate('/inscripcion-exitosa', { state: { courseTitle: course?.title } })
   }


### PR DESCRIPTION
## Summary
- track exam attempts in auth store
- persist maxAttempts, attempts and lastAttempt per course
- show progress percentage inside progress bar
- enforce 24h wait and attempt limit before retaking final exam
- make module cards fully clickable

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685a02cb6e74832f99411dde03e9de0b