### PR TITLE
Ajustes en progress y datos de cursos

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -27,7 +27,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-html-css.png',
     duration: '4 semanas',
     level: 'Principiante',
-    maxAttempts: 3,
+    maxAttempts: 2,
     modules: [
       {
         id: '1',
@@ -126,7 +126,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react.png',
     duration: '6 semanas',
     level: 'Intermedio',
-    maxAttempts: 3,
+    maxAttempts: 2,
     modules: [
       {
         id: '1',
@@ -168,7 +168,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-node.png',
     duration: '5 semanas',
     level: 'Intermedio',
-    maxAttempts: 3,
+    maxAttempts: 4,
     modules: [
       {
         id: '1',
@@ -210,7 +210,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-ts.png',
     duration: '6 semanas',
     level: 'Avanzado',
-    maxAttempts: 3,
+    maxAttempts: 5,
     modules: [
       {
         id: '1',
@@ -318,7 +318,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-jest.png',
     duration: '4 semanas',
     level: 'Intermedio',
-    maxAttempts: 3,
+    maxAttempts: 2,
     modules: [
       {
         id: '1',
@@ -360,7 +360,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react-native.png',
     duration: '7 semanas',
     level: 'Intermedio',
-    maxAttempts: 3,
+    maxAttempts: 4,
     modules: [
       {
         id: '1',

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -50,6 +50,7 @@ export default function CourseDetail() {
             <span className="px-3 py-1 bg-gray-200 rounded underline font-semibold">Dificultad: {course.level}</span>
             <span className="px-3 py-1 bg-gray-200 rounded">Duración: {course.duration}</span>
             <span className="px-3 py-1 bg-gray-200 rounded">Módulos: {course.modules.length}</span>
+            <span className="px-3 py-1 bg-gray-200 rounded">Intentos de evaluación: {course.maxAttempts}</span>
           </div>
           <h2 className="text-2xl font-bold">Preguntas frecuentes</h2>
           <p>
@@ -80,7 +81,7 @@ export default function CourseDetail() {
                     ? `Curso finalizado - Nota: ${progress.grade}`
                     : progress.completed >= progress.total
                       ? 'Curso finalizado'
-                      : `${Math.round((progress.completed / progress.total) * 100)}% completado`}
+                      : 'Actualmente en curso'}
                   {progress.completed >= progress.total && progress.grade !== undefined && (
                     <span
                       className={`ml-1 px-2 py-0.5 rounded text-xs ${
@@ -104,7 +105,10 @@ export default function CourseDetail() {
                   attemptsRemaining > 0 ? (
                     <>
                       <p className="text-sm text-red-600">
-                        Debes volver a contestar la evaluación
+                        Debes volver a contestar la evaluación.
+                        {!canRetakeExam &&
+                          ' Debes esperar 24 horas antes de volver a responder esta evaluación.'}
+                        {' '}Te quedan {attemptsRemaining} intentos.
                       </p>
                       {canRetakeExam ? (
                         <Button onClick={() => navigate(`/cursos/${id}/examen-final`)}>


### PR DESCRIPTION
## Summary
- tweak course progress view: show `Actualmente en curso` and add remaining attempts message
- add course attempt info in details and vary max attempts per course

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a05c71dc8832fb45fe624594000f8