### PR TITLE
Improve module navigation

### DIFF
--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -74,7 +74,6 @@ export default function Module() {
             >
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
             </svg>
-            <span>Volver</span>
           </button>
           <Link to="/cursos" className="text-blue-600 underline">Cursos</Link>
           {course && (
@@ -87,24 +86,6 @@ export default function Module() {
             </>
           )}
         </nav>
-        <div className="flex justify-between w-full">
-          {prevModule && (
-            <Button
-              onClick={() => navigate(`/cursos/${id}/modulo/${prevModule.id}`)}
-              className="px-6 py-3"
-            >
-              Anterior
-            </Button>
-          )}
-          {nextModule && (
-            <Button
-              onClick={() => navigate(`/cursos/${id}/modulo/${nextModule.id}`)}
-              className="ml-auto px-6 py-3"
-            >
-              Siguiente
-            </Button>
-          )}
-        </div>
         {course && module ? (
           <>
             <h1 className="text-3xl font-bold text-center">
@@ -118,8 +99,7 @@ export default function Module() {
               </div>
             ) : isLogged && isEnrolled && !canAccess ? (
               <p className="italic text-center">
-                Primero debes completar el módulo{' '}
-                {course?.modules.find(m => m.id === String(moduleNumber - 1))?.title}
+                Primero debes completar el Módulo {prevModule?.id} "{prevModule?.title}"
               </p>
             ) : isLogged ? (
               <p className="italic text-center">Inscríbete para ver el contenido de este módulo.</p>
@@ -147,22 +127,43 @@ export default function Module() {
         ) : isLogged ? null : (
           <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
         )}
-        <div className="flex justify-between w-full mt-4">
+        <hr className="my-4" />
+        <div className="flex justify-between w-full max-w-xl mx-auto">
           {prevModule && (
-            <Button
+            <button
               onClick={() => navigate(`/cursos/${id}/modulo/${prevModule.id}`)}
-              className="px-6 py-3"
+              className="flex items-center gap-2 border border-black px-4 py-2"
             >
-              Anterior
-            </Button>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+              </svg>
+              <span className="text-sm">Módulo {prevModule.id} - {prevModule.title}</span>
+            </button>
           )}
           {nextModule && (
-            <Button
+            <button
               onClick={() => navigate(`/cursos/${id}/modulo/${nextModule.id}`)}
-              className="ml-auto px-6 py-3"
+              className="flex items-center gap-2 border border-black px-4 py-2"
             >
-              Siguiente
-            </Button>
+              <span className="text-sm">Módulo {nextModule.id} - {nextModule.title}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-4 h-4"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+              </svg>
+            </button>
           )}
         </div>
       </main>


### PR DESCRIPTION
## Summary
- remove text from back button in module breadcrumb
- show required module number when trying to access locked module
- style previous/next module navigation with arrows and module titles
- add divider before navigation links

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a0bd930cc832f8f02bd3b8defeba1