### PR TITLE
Show module number and add separators

### DIFF
--- a/src/pages/Module.tsx
+++ b/src/pages/Module.tsx
@@ -124,6 +124,10 @@ export default function Module() {
             </button>
           )}
         </div>
+        <hr className="my-4" />
+        {moduleId && (
+          <h2 className="text-center text-xl font-semibold">Módulo {moduleId}</h2>
+        )}
         {course && module ? (
           <>
             <h1 className="text-3xl font-bold text-center">


### PR DESCRIPTION
## Summary
- show module number between navigation buttons and module title
- add an `<hr>` under the top navigation bar

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a0f3a0668832fafc7eefd14c15864