### PR TITLE
Add user flow page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Dentro de la carpeta `Wireframes` hay dos plantillas HTML estáticas que represe
 Ambas plantillas utilizan rectángulos y círculos grises para ilustrar la ubicación de los elementos.
 
 Además, la aplicación cuenta con una ruta `/wireframes` que lista enlaces a todas estas plantillas para poder visualizarlas de forma ordenada.
+
+## Flujo de usuario
+
+Existe una ruta `/flujo` que muestra de forma resumida los pasos que sigue una persona usuaria desde la página de inicio hasta completar un curso. Esta pantalla repasa en qué momentos es obligatorio iniciar sesión para continuar.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Nosotros from './pages/Nosotros'
 import ErrorPage from './pages/ErrorPage'
 import NotFound from './pages/NotFound'
 import Wireframes from './pages/Wireframes'
+import UserFlow from './pages/UserFlow'
 
 export default function App() {
   return (
@@ -31,6 +32,7 @@ export default function App() {
       <Route path="/foro" element={<Forum />} />
       <Route path="/nosotros" element={<Nosotros />} />
       <Route path="/wireframes" element={<Wireframes />} />
+      <Route path="/flujo" element={<UserFlow />} />
       <Route path="/error" element={<ErrorPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/pages/UserFlow.tsx
+++ b/src/pages/UserFlow.tsx
@@ -1,0 +1,60 @@
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export default function UserFlow() {
+  const steps = [
+    {
+      title: 'Home',
+      desc: 'Página inicial con acceso al catálogo de cursos',
+    },
+    {
+      title: 'Cursos',
+      desc: 'Lista completa de cursos disponibles',
+    },
+    {
+      title: 'Detalle del curso',
+      desc:
+        'Información del curso y opción para inscribirse. Si no has iniciado sesión, se solicitará hacerlo',
+    },
+    {
+      title: 'Login',
+      desc:
+        'Paso obligatorio para inscribirse y acceder al contenido de los módulos',
+    },
+    {
+      title: 'Formulario de inscripción',
+      desc: 'Registro al curso una vez iniciada la sesión',
+    },
+    {
+      title: 'Módulos',
+      desc:
+        'Lecciones del curso. Se desbloquean en orden y requieren sesión activa',
+    },
+    {
+      title: 'Examen final',
+      desc: 'Disponible al completar todos los módulos',
+    },
+    {
+      title: 'Dashboard',
+      desc:
+        'Resumen del progreso, calificaciones y acceso al resto de funcionalidades',
+    },
+  ]
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="container mx-auto flex-grow p-4 space-y-4">
+        <h1 className="text-3xl font-bold">Flujo de usuario</h1>
+        <ol className="list-decimal pl-5 space-y-2">
+          {steps.map(step => (
+            <li key={step.title}>
+              <span className="font-semibold">{step.title}</span> – {step.desc}
+            </li>
+          ))}
+        </ol>
+      </main>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new `UserFlow` screen detailing the app navigation steps
- document new route `/flujo` in README
- register the route in `App.tsx`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685a1e390680832f91a1e63b30cb46e4