### PR TITLE
Update course page with new progress logic

### DIFF
--- a/src/utils/getNextClassLink.ts
+++ b/src/utils/getNextClassLink.ts
@@ -1,0 +1,21 @@
+import { CourseInfo } from '../data/courses'
+import { Course } from '../store/auth'
+
+export default function getNextClassLink(course: CourseInfo, progress?: Course): string | null {
+  for (const module of course.modules) {
+    const moduleIndex = parseInt(module.id, 10)
+    const classes = module.classes ?? []
+    if (classes.length > 0) {
+      const done = progress?.classProgress[module.id] ?? []
+      const next = classes.find(c => !done.includes(c.id))
+      if (next) {
+        return `/cursos/${course.id}/modulo/${module.id}/clase/${next.id}`
+      }
+    } else {
+      if (!progress || progress.completed < moduleIndex) {
+        return `/cursos/${course.id}/modulo/${module.id}`
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- show modules permanently expanded and list classes with index
- display only avatar icon for the instructor
- compute progress based on completed classes
- jump to next class when continuing a course
- update course cards to use new progress calculation
- add helper `getNextClassLink`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685dc7e05c4c832fb126b226d03bc124