### PR TITLE
Fix type-only imports for next class link

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -46,7 +46,9 @@ export default function CourseCard({
       }, 0)
     : 0
   const percent = totalClasses ? Math.round((completedClasses / totalClasses) * 100) : 0
-  const nextLink = course ? getNextClassLink(course, progress) : `/cursos/${id}`
+  const nextLink = course
+    ? getNextClassLink(course, progress) ?? `/cursos/${id}`
+    : `/cursos/${id}`
 
   return (
     <div className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-full min-w-[300px]">

--- a/src/utils/getNextClassLink.ts
+++ b/src/utils/getNextClassLink.ts
@@ -1,5 +1,5 @@
-import { CourseInfo } from '../data/courses'
-import { Course } from '../store/auth'
+import type { CourseInfo } from '../data/courses'
+import type { Course } from '../store/auth'
 
 export default function getNextClassLink(course: CourseInfo, progress?: Course): string | null {
   for (const module of course.modules) {


### PR DESCRIPTION
## Summary
- import `CourseInfo` as type-only in getNextClassLink
- handle null return value in CourseCard

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685dca680328832f83022dd7d778bcb4