### PR TITLE
Fix notebook style alignment for class list

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,9 +10,9 @@ body {
 .lined-paper {
   background-image: repeating-linear-gradient(
     to bottom,
-    #ffffff,
-    #ffffff 32px,
-    #e5e7eb 32px,
-    #e5e7eb 33px
+    #ffffff 0,
+    #ffffff 2.5rem,
+    #e5e7eb 2.5rem,
+    #e5e7eb calc(2.5rem + 1px)
   );
 }

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -221,7 +221,7 @@ export default function CourseDetail() {
                         <li key={c.id}>
                           <Link
                             to={`/cursos/${id}/modulo/${m.id}/clase/${c.id}`}
-                            className="flex justify-between items-center py-2 hover:bg-gray-50"
+                            className="flex justify-between items-center py-2 min-h-[2.5rem] hover:bg-gray-50"
                           >
                             <div className="flex items-center gap-2">
                               <Icon className={`w-6 h-6 ${done ? 'text-green-600' : 'text-gray-400'}`} />


### PR DESCRIPTION
## Summary
- tweak `lined-paper` CSS to use responsive `rem` units and consistent spacing
- ensure class rows have consistent height for alignment

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685efefffc14832f9938ce124af01327