### PR TITLE
Improve course card layout and navigation

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -51,7 +51,7 @@ export default function CourseCard({
     : `/cursos/${id}`
 
   return (
-    <div className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-full min-w-[300px]">
+    <div className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-full">
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
         <img
           src={image}

--- a/src/pages/Class.tsx
+++ b/src/pages/Class.tsx
@@ -95,12 +95,7 @@ export default function ClassPage() {
             {course.title}
           </Link>
           <span>/</span>
-          <Link
-            to={`/cursos/${course.id}/modulo/${module.id}/clase/${classes[0].id}`}
-            className="text-blue-600 underline"
-          >
-            Módulo {module.id}
-          </Link>
+          <span>Módulo {module.id}</span>
           <span>/ Clase {currentClass.id}</span>
         </nav>
         <h1 className="text-2xl font-bold text-center">

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -89,6 +89,7 @@ export default function CourseDetail() {
                   revisar los requisitos previos y los términos de aprobación.
                 </p>
                 <Button
+                  className="bg-orange-500 hover:bg-orange-600 text-white"
                   onClick={() => {
                     if (!isLogged) {
                       navigate('/login')

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -82,7 +82,7 @@ export default function Home() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
             </button>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 flex-grow">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 flex-grow">
               {pageCourses.map(course => (
                 <CourseCard
                   key={course.id}


### PR DESCRIPTION
## Summary
- prevent overlap by removing min width on `CourseCard`
- adjust featured courses grid responsiveness
- match color of "Comenzar" button with course cards
- simplify class breadcrumb links

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68600906b178832fa0b7de9e4c86da2f