### PR TITLE
Fix responsive grid for course cards

### DIFF
--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+              <div className="grid gap-6 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+          <div className="grid gap-6 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -71,7 +71,7 @@ export default function Dashboard() {
                 {currentCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Cursos en curso</h2>
-                    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                       {currentCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
                         const nextLink = info ? getNextClassLink(info, course) : null
@@ -137,7 +137,7 @@ export default function Dashboard() {
                 {finishedCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Cursos finalizados</h2>
-                    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                       {finishedCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
                         return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -82,7 +82,7 @@ export default function Home() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
             </button>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 flex-grow">
+            <div className="grid gap-4 flex-grow [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
               {pageCourses.map(course => (
                 <CourseCard
                   key={course.id}


### PR DESCRIPTION
## Summary
- avoid overlapping course cards by using CSS grid auto-fit

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68601078af0c832fb15c590ebe48101d