### PR TITLE
Fix card width

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -51,7 +51,7 @@ export default function CourseCard({
     : `/cursos/${id}`
 
   return (
-    <div className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-full">
+    <div className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-[300px]">
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
         <img
           src={image}

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-6 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+              <div className="grid gap-6 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-6 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+          <div className="grid gap-6 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -71,7 +71,7 @@ export default function Dashboard() {
                 {currentCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Cursos en curso</h2>
-                    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+                    <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                       {currentCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
                         const nextLink = info ? getNextClassLink(info, course) : null
@@ -85,7 +85,7 @@ export default function Dashboard() {
                         return (
                           <div
                             key={course.id}
-                            className="border p-4 rounded shadow flex flex-col items-center gap-2 w-full overflow-hidden"
+                            className="border p-4 rounded shadow flex flex-col items-center gap-2 w-[300px] overflow-hidden"
                           >
                             {info?.image && (
                               <img
@@ -137,13 +137,13 @@ export default function Dashboard() {
                 {finishedCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Cursos finalizados</h2>
-                    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+                    <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                       {finishedCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
                         return (
                           <div
                             key={course.id}
-                            className="border p-4 rounded shadow flex flex-col gap-2 w-full"
+                            className="border p-4 rounded shadow flex flex-col gap-2 w-[300px]"
                           >
                             {info?.image && (
                               <img

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -82,7 +82,7 @@ export default function Home() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
             </button>
-            <div className="grid gap-4 flex-grow [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+            <div className="grid gap-4 flex-grow justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
               {pageCourses.map(course => (
                 <CourseCard
                   key={course.id}


### PR DESCRIPTION
## Summary
- maintain 300px width for `CourseCard`
- center grid layouts for courses on Dashboard, Home and Courses pages

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68601408a6f4832fa76d45ea39dcdf38