### PR TITLE
Update class page navigation and data

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -3,6 +3,10 @@ export interface ClassInfo {
   title: string
   /** Types of content available in the class */
   content: ('video' | 'text' | 'document' | 'questions')[]
+  /** Estimated duration when the class includes a video */
+  duration?: string
+  /** Description paragraphs for the class */
+  description: string[]
 }
 
 export interface ModuleInfo {
@@ -57,9 +61,34 @@ export const courses: CourseInfo[] = [
           'Conocerás los actores principales de internet y cómo se enlazan para mostrar páginas en tu navegador.',
         videoUrl: '#',
         classes: [
-          { id: '1', title: 'Presentación', content: ['video'] },
-          { id: '2', title: 'Lecturas recomendadas', content: ['text', 'document'] },
-          { id: '3', title: 'Preguntas', content: ['questions'] },
+          {
+            id: '1',
+            title: 'Presentación',
+            content: ['video'],
+            duration: '5m',
+            description: [
+              'En este video daremos la bienvenida al curso y explicaremos la dinámica de trabajo.',
+              'También revisaremos qué conocimientos previos son necesarios para aprovechar cada lección.',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Lecturas recomendadas',
+            content: ['text', 'document'],
+            description: [
+              'Te compartiremos enlaces a artículos que amplían los conceptos vistos en la clase anterior.',
+              'Además podrás descargar un PDF con material complementario para repasar cuando quieras.',
+            ],
+          },
+          {
+            id: '3',
+            title: 'Preguntas',
+            content: ['questions'],
+            description: [
+              'Aquí encontrarás un breve cuestionario para evaluar tu comprensión de los temas iniciales.',
+              'No olvides completar este apartado para continuar con el siguiente módulo.',
+            ],
+          },
         ],
       },
       {
@@ -70,8 +99,25 @@ export const courses: CourseInfo[] = [
           'Verás las etiquetas fundamentales para definir encabezados, listas y secciones, creando bases sólidas de tus documentos.',
         videoUrl: '#',
         classes: [
-          { id: '1', title: 'Etiquetas básicas', content: ['video', 'text'] },
-          { id: '2', title: 'Documento de ejemplo', content: ['document'] },
+          {
+            id: '1',
+            title: 'Etiquetas básicas',
+            content: ['video', 'text'],
+            duration: '8m',
+            description: [
+              'Aprenderás cuáles son las etiquetas esenciales para crear la estructura de una página web.',
+              'Revisaremos ejemplos prácticos y algunas buenas prácticas al escribir HTML.',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Documento de ejemplo',
+            content: ['document'],
+            description: [
+              'Descargarás un documento con el código de ejemplo utilizado durante la clase anterior.',
+              'Utiliza este material como referencia para tus propios proyectos.',
+            ],
+          },
         ],
       },
       {
@@ -83,8 +129,25 @@ export const courses: CourseInfo[] = [
           'Aprenderás a cambiar colores, tipografías y disposiciones para lograr sitios atractivos y consistentes en todos los dispositivos.',
         videoUrl: '#',
         classes: [
-          { id: '1', title: 'Selectores', content: ['video'] },
-          { id: '2', title: 'Ejercicios', content: ['document', 'questions'] },
+          {
+            id: '1',
+            title: 'Selectores',
+            content: ['video'],
+            duration: '7m',
+            description: [
+              'Exploraremos los distintos tipos de selectores de CSS y cuándo conviene utilizar cada uno.',
+              'Verás ejemplos que te ayudarán a escribir reglas más precisas y mantenibles.',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Ejercicios',
+            content: ['document', 'questions'],
+            description: [
+              'Encontrarás una guía de ejercicios para practicar los selectores aprendidos.',
+              'Al finalizar podrás validar tus respuestas en la sección de preguntas incluidas.',
+            ],
+          },
         ],
       },
       {
@@ -96,8 +159,26 @@ export const courses: CourseInfo[] = [
           'Descubrirás técnicas con flexbox y media queries que adaptan el contenido a cualquier tamaño de pantalla.',
         videoUrl: '#',
         classes: [
-          { id: '1', title: 'Flexbox', content: ['video'] },
-          { id: '2', title: 'Media queries', content: ['video', 'text'] },
+          {
+            id: '1',
+            title: 'Flexbox',
+            content: ['video'],
+            duration: '6m',
+            description: [
+              'Conocerás el modelo de cajas flexibles para acomodar elementos de forma sencilla.',
+              'Mediante ejemplos prácticos verás cómo alinear y distribuir bloques en cualquier pantalla.',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Media queries',
+            content: ['video', 'text'],
+            duration: '9m',
+            description: [
+              'Aprenderás a adaptar tus estilos utilizando breakpoints responsivos.',
+              'Combinaremos media queries con flexbox para lograr diseños fluidos y accesibles.',
+            ],
+          },
         ],
       },
       {
@@ -109,8 +190,24 @@ export const courses: CourseInfo[] = [
           'Combinaremos todos los temas anteriores para crear desde cero una página completa lista para publicar.',
         videoUrl: '#',
         classes: [
-          { id: '1', title: 'Planificación', content: ['text'] },
-          { id: '2', title: 'Entrega', content: ['document', 'questions'] },
+          {
+            id: '1',
+            title: 'Planificación',
+            content: ['text'],
+            description: [
+              'Definiremos los objetivos del sitio web que construirás como trabajo final.',
+              'Organizaremos las tareas en pasos pequeños para avanzar de forma ordenada.',
+            ],
+          },
+          {
+            id: '2',
+            title: 'Entrega',
+            content: ['document', 'questions'],
+            description: [
+              'Revisarás los criterios de evaluación y el formato de entrega del proyecto.',
+              'También responderás un breve cuestionario sobre tu experiencia desarrollando el curso.',
+            ],
+          },
         ],
       },
     ],

--- a/src/pages/Class.tsx
+++ b/src/pages/Class.tsx
@@ -3,7 +3,13 @@ import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useEffect } from 'react'
+import {
+  PlayCircleIcon,
+  DocumentIcon,
+  DocumentTextIcon,
+} from '@heroicons/react/24/solid'
 import { courses } from '../data/courses'
+import type { ClassInfo } from '../data/courses'
 import { useAuthStore } from '../store/auth'
 
 export default function ClassPage() {
@@ -19,22 +25,18 @@ export default function ClassPage() {
   const course = courses.find(c => c.id === id)
   const module = course?.modules.find(m => m.id === moduleId)
   const classes =
-    module?.classes ?? Array.from({ length: 3 }, (_, i) => ({
+    module?.classes ??
+    (Array.from({ length: 3 }, (_, i) => ({
       id: `${i + 1}`,
       title: `Clase ${i + 1}`,
       content: ['video'],
-    }))
+      duration: '0m',
+      description: ['Contenido no disponible'],
+    })) as ClassInfo[])
   const index = classes.findIndex(c => c.id === classId)
   const currentClass = classes[index]
   const prevClass = index > 0 ? classes[index - 1] : null
   const nextClass = index >= 0 && index < classes.length - 1 ? classes[index + 1] : null
-  const moduleIndex = course?.modules.findIndex(m => m.id === moduleId) ?? -1
-  const prevModule =
-    moduleIndex > 0 && course ? course.modules[moduleIndex - 1] : null
-  const nextModule =
-    course && moduleIndex >= 0 && moduleIndex < course.modules.length - 1
-      ? course.modules[moduleIndex + 1]
-      : null
   const completedClasses = progress?.classProgress[moduleId ?? ''] ?? []
   const isCompleted = completedClasses.includes(classId ?? '')
 
@@ -65,10 +67,9 @@ export default function ClassPage() {
       <main className="container mx-auto flex-grow p-4 flex flex-col lg:flex-row gap-6">
         <section className="flex-grow space-y-4">
           <nav className="text-sm flex items-center gap-2">
-            <button
-              onClick={() => navigate(-1)}
-              aria-label="Volver"
-              className="flex items-center gap-1 p-1"
+            <Link
+              to={`/cursos/${course.id}`}
+              className="flex items-center gap-1 text-blue-600 underline"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -80,62 +81,30 @@ export default function ClassPage() {
               >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
-            </button>
-            <Link to="/cursos" className="text-blue-600 underline">Cursos</Link>
-            <span>/</span>
-            <Link to={`/cursos/${course.id}`} className="text-blue-600 underline">
-              {course.title}
+              <span>Volver al curso {course.title}</span>
             </Link>
-            <span>/</span>
-            <span>Módulo {module.id}</span>
-            <span>/ Clase {currentClass.id}</span>
+            <span>/ Módulo {module.id} / Clase {currentClass.id}</span>
           </nav>
-          <video
-            src={module.videoUrl}
-            controls
-            className="w-full max-h-80 bg-black"
-          />
-          <h1 className="text-2xl font-bold">{currentClass.title}</h1>
-          <p>{module.description}</p>
           {isLogged ? (
-            <Button onClick={handleComplete} disabled={isCompleted} className="w-full max-w-xs">
-              {isCompleted ? 'Completada' : 'Marcar la lección como completa'}
-            </Button>
+            isCompleted ? (
+              <p className="text-sm">
+                Ya has marcado como completada esta clase. Pero puedes volver a
+                ver el contenido cuando quieras.
+              </p>
+            ) : (
+              <Button onClick={handleComplete} className="w-full max-w-xs">
+                Marcar lección como completa
+              </Button>
+            )
           ) : (
             <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
           )}
-          <div className="flex justify-between">
-            {prevClass ? (
-              <Link
-                to={`/cursos/${id}/modulo/${moduleId}/clase/${prevClass.id}`}
-                className="text-blue-600 underline"
-              >
-                ← Clase {prevClass.id}
-              </Link>
-            ) : (
-              <span />
-            )}
-            {nextClass ? (
-              <Link
-                to={`/cursos/${id}/modulo/${moduleId}/clase/${nextClass.id}`}
-                className="text-blue-600 underline"
-              >
-                Clase {nextClass.id} →
-              </Link>
-            ) : (
-              <span />
-            )}
-          </div>
           <hr className="my-4" />
           <div className="flex justify-center gap-4">
-            {prevModule && (
+            {prevClass && (
               <button
                 onClick={() =>
-                  navigate(
-                    `/cursos/${id}/modulo/${prevModule.id}/clase/${
-                      prevModule.classes?.[0]?.id ?? '1'
-                    }`,
-                  )
+                  navigate(`/cursos/${id}/modulo/${moduleId}/clase/${prevClass.id}`)
                 }
                 className="flex items-center gap-2 border border-black px-4 py-4 w-64"
               >
@@ -149,21 +118,106 @@ export default function ClassPage() {
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
                 </svg>
-                <span className="text-sm">Módulo {prevModule.id} - {prevModule.title}</span>
+                <span className="text-sm">Clase {prevClass.id} - {prevClass.title}</span>
               </button>
             )}
-            {nextModule && (
+            {nextClass && (
               <button
                 onClick={() =>
-                  navigate(
-                    `/cursos/${id}/modulo/${nextModule.id}/clase/${
-                      nextModule.classes?.[0]?.id ?? '1'
-                    }`,
-                  )
+                  navigate(`/cursos/${id}/modulo/${moduleId}/clase/${nextClass.id}`)
                 }
                 className="flex items-center gap-2 border border-black px-4 py-4 w-64"
               >
-                <span className="text-sm">Módulo {nextModule.id} - {nextModule.title}</span>
+                <span className="text-sm">Clase {nextClass.id} - {nextClass.title}</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <h2 className="text-xl font-bold">Material de la clase</h2>
+          <ul className="space-y-2">
+            {currentClass.content.map(type => {
+              const Icon =
+                type === 'video'
+                  ? PlayCircleIcon
+                  : type === 'document'
+                  ? DocumentIcon
+                  : DocumentTextIcon
+              const label =
+                type === 'video'
+                  ? `Video · ${currentClass.duration ?? '---'}`
+                  : type === 'document'
+                  ? 'Documento descargable'
+                  : 'Lectura'
+              return (
+                <li key={type} className="flex items-center gap-2">
+                  <Icon className="w-5 h-5" />
+                  <span>{label}</span>
+                </li>
+              )
+            })}
+          </ul>
+          <h1 className="text-2xl font-bold">{currentClass.title}</h1>
+          {currentClass.description.map((p: string, i: number) => (
+            <p key={i}>{p}</p>
+          ))}
+          <video
+            src={module.videoUrl}
+            controls
+            className="w-full max-h-80 bg-black"
+          />
+          {isLogged ? (
+            isCompleted ? (
+              <p className="text-sm">
+                Ya has marcado como completada esta clase. Pero puedes volver a
+                ver el contenido cuando quieras.
+              </p>
+            ) : (
+              <Button onClick={handleComplete} className="w-full max-w-xs">
+                Marcar lección como completa
+              </Button>
+            )
+          ) : (
+            <Button onClick={() => navigate('/login')}>Inicia sesión para continuar</Button>
+          )}
+          <hr className="my-4" />
+          <div className="flex justify-center gap-4">
+            {prevClass && (
+              <button
+                onClick={() =>
+                  navigate(`/cursos/${id}/modulo/${moduleId}/clase/${prevClass.id}`)
+                }
+                className="flex items-center gap-2 border border-black px-4 py-4 w-64"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                </svg>
+                <span className="text-sm">Clase {prevClass.id} - {prevClass.title}</span>
+              </button>
+            )}
+            {nextClass && (
+              <button
+                onClick={() =>
+                  navigate(`/cursos/${id}/modulo/${moduleId}/clase/${nextClass.id}`)
+                }
+                className="flex items-center gap-2 border border-black px-4 py-4 w-64"
+              >
+                <span className="text-sm">Clase {nextClass.id} - {nextClass.title}</span>
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"


### PR DESCRIPTION
## Summary
- extend `ClassInfo` with duration and description
- add description and duration data for HTML/CSS classes
- revamp Class page with clearer breadcrumbs, material info and class navigation

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686023aa7bbc832fb18e5e2baf4ce9e2