### PR TITLE
Add prerequisites block to course detail

### DIFF
--- a/src/components/PrerequisiteCourses.tsx
+++ b/src/components/PrerequisiteCourses.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import { courses } from '../data/courses'
+
+interface Props {
+  courseIds: string[]
+}
+
+export default function PrerequisiteCourses({ courseIds }: Props) {
+  const list = courses.filter(c => courseIds.includes(c.id))
+  if (list.length === 0) return null
+  return (
+    <section className="border-2 border-gray-300 rounded p-4 space-y-2">
+      <h2 className="text-2xl font-bold">Cursos requeridos</h2>
+      <p className="text-sm">Debes completar previamente los siguientes cursos:</p>
+      <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {list.map(c => (
+          <li key={c.id}>
+            <Link to={`/cursos/${c.id}`} className="flex items-center gap-2">
+              <img src={c.image} alt={c.title} className="w-12 h-12 object-cover rounded" />
+              <span className="text-blue-600 underline">{c.title}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -1,6 +1,7 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
+import PrerequisiteCourses from '../components/PrerequisiteCourses'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 
 import {
@@ -82,6 +83,10 @@ export default function CourseDetail() {
                 <span className="px-3 py-1 bg-gray-200 rounded">Intentos de evaluación: {course.maxAttempts}</span>
               </div>
             </section>
+            {course.prerequisites?.courses &&
+              course.prerequisites.courses.length > 0 && (
+                <PrerequisiteCourses courseIds={course.prerequisites.courses} />
+              )}
             {!progress && (
               <section className="border-2 border-gray-300 rounded p-4 space-y-3">
                 <p className="font-semibold">


### PR DESCRIPTION
## Summary
- list prerequisite courses with thumbnail in new component
- show prerequisite block in Course detail before enrollment action

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860392363bc832f871d8273ffe2ad0c