### PR TITLE
Add icon and styling for prerequisite course list

### DIFF
--- a/src/components/PrerequisiteCourses.tsx
+++ b/src/components/PrerequisiteCourses.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { AcademicCapIcon } from '@heroicons/react/24/solid'
 import { courses } from '../data/courses'
 
 interface Props {
@@ -12,12 +13,15 @@ export default function PrerequisiteCourses({ courseIds }: Props) {
     <section className="border-2 border-gray-300 rounded p-4 space-y-2">
       <h2 className="text-2xl font-bold">Cursos requeridos</h2>
       <p className="text-sm">Debes completar previamente los siguientes cursos:</p>
-      <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <ul className="space-y-2">
         {list.map(c => (
           <li key={c.id}>
-            <Link to={`/cursos/${c.id}`} className="flex items-center gap-2">
-              <img src={c.image} alt={c.title} className="w-12 h-12 object-cover rounded" />
-              <span className="text-blue-600 underline">{c.title}</span>
+            <Link
+              to={`/cursos/${c.id}`}
+              className="flex items-center gap-2 text-black hover:text-black no-underline"
+            >
+              <AcademicCapIcon className="w-5 h-5 text-gray-500" />
+              <span className="font-semibold">{c.title}</span>
             </Link>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- show prerequisite courses in a simple list
- add a course icon and remove link styling

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68603bba94bc832fa94420c6a2693558