### PR TITLE
Fix course card width and grid layout

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -52,7 +52,7 @@ export default function CourseCard({
 
   return (
     <div
-      className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 min-w-[300px] max-w-[300px]"
+      className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 min-w-[360px] max-w-[360px]"
     >
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
         <img

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+              <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,_360px)]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,_360px)]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}


### PR DESCRIPTION
## Summary
- make CourseCard 360px wide
- adjust grid in Courses page to avoid wide gaps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686040f52a08832f8ccf34a8d8e8cd9d