### PR TITLE
Update evaluation button and grade messages

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -69,7 +69,10 @@ export default function CourseCard({
               <>
                 <p className="font-semibold text-green-700">Curso finalizado</p>
                 <p>
-                  Nota: {progress.grade ?? '-'}{' '}
+                  Nota:{' '}
+                  {progress.grade !== undefined
+                    ? progress.grade
+                    : 'Contesta la evaluación para recibir tu calificacion'}{' '}
                   {progress.grade !== undefined && (
                     <span
                       className={`ml-1 px-2 py-0.5 rounded text-xs ${
@@ -134,7 +137,7 @@ export default function CourseCard({
             <span>
               {isEnrolled
                 ? showExam
-                  ? 'CONTESTAR EVALUACIÓN'
+                  ? 'EVALUACIÓN'
                   : 'SEGUIR'
                 : 'COMENZAR'}
             </span>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -156,7 +156,10 @@ export default function Dashboard() {
                               {course.title}
                             </h2>
                             <p className="text-center font-semibold">
-                              Nota: {course.grade ?? '-'}{' '}
+                              Nota:{' '}
+                              {course.grade !== undefined
+                                ? course.grade
+                                : 'Contesta la evaluación para recibir tu calificacion'}{' '}
                               {course.grade !== undefined && (
                                 <span
                                   className={`ml-1 px-2 py-0.5 rounded text-xs ${


### PR DESCRIPTION
## Summary
- show message when grade is not available yet
- change course card exam button label to `EVALUACIÓN`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_686045657310832fa992ac1bfd2b38dd