### PR TITLE
Fix overflow in courses layout

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -52,7 +52,7 @@ export default function CourseCard({
 
   return (
     <div
-      className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 min-w-[360px] max-w-[360px]"
+      className="border-2 border-gray-300 p-4 rounded shadow hover:shadow-lg flex flex-col gap-4 w-full sm:w-[360px]"
     >
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
         <img
@@ -72,7 +72,7 @@ export default function CourseCard({
                   Nota:{' '}
                   {progress.grade !== undefined
                     ? progress.grade
-                    : 'Contesta la evaluación para recibir tu calificacion'}{' '}
+                    : 'Contesta la evaluación para recibir tu calificación.'}{' '}
                   {progress.grade !== undefined && (
                     <span
                       className={`ml-1 px-2 py-0.5 rounded text-xs ${

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,_360px)]">
+              <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,_360px)]">
+          <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -159,7 +159,7 @@ export default function Dashboard() {
                               Nota:{' '}
                               {course.grade !== undefined
                                 ? course.grade
-                                : 'Contesta la evaluación para recibir tu calificacion'}{' '}
+                                : 'Contesta la evaluación para recibir tu calificación.'}{' '}
                               {course.grade !== undefined && (
                                 <span
                                   className={`ml-1 px-2 py-0.5 rounded text-xs ${


### PR DESCRIPTION
## Summary
- prevent course cards from forcing horizontal scroll on small screens
- correct pending evaluation text

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6860470cfdb0832fa29e9e6793b0abac