### PR TITLE
Add standalone HTML error page

### DIFF
--- a/error-standalone.html
+++ b/error-standalone.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Error - Aula Digital Ciudadana</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: sans-serif;
+      height: 100%;
+    }
+    body {
+      background: linear-gradient(135deg, #f87171, #ef4444);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      color: #fff;
+      text-align: center;
+    }
+    h1 {
+      font-size: 2.5rem;
+      margin-bottom: 0.5rem;
+    }
+    p {
+      margin-bottom: 1.5rem;
+    }
+    button {
+      padding: 0.75rem 1.5rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 0.375rem;
+      background: #fff;
+      color: #ef4444;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    button:hover {
+      background: #f5f5f5;
+    }
+  </style>
+</head>
+<body>
+  <h1>Ocurrió un error</h1>
+  <p>Intenta nuevamente más tarde.</p>
+  <button id="home-btn">Volver al inicio</button>
+  <script>
+    document.getElementById('home-btn').addEventListener('click', function() {
+      window.location.href = '/';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a complete HTML file with styles and JS for a standalone error page

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860665c38e4832fa5fa60e39b139044