### PR TITLE
Add navbar and footer to error page

### DIFF
--- a/error-standalone.html
+++ b/error-standalone.html
@@ -4,51 +4,86 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Error - Aula Digital Ciudadana</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      font-family: sans-serif;
-      height: 100%;
-    }
-    body {
-      background: linear-gradient(135deg, #f87171, #ef4444);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-direction: column;
-      color: #fff;
-      text-align: center;
-    }
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 0.5rem;
-    }
-    p {
-      margin-bottom: 1.5rem;
-    }
-    button {
-      padding: 0.75rem 1.5rem;
-      font-size: 1rem;
-      border: none;
-      border-radius: 0.375rem;
-      background: #fff;
-      color: #ef4444;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-    button:hover {
-      background: #f5f5f5;
-    }
-  </style>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <h1>Ocurrió un error</h1>
-  <p>Intenta nuevamente más tarde.</p>
-  <button id="home-btn">Volver al inicio</button>
+<body class="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex flex-col min-h-screen">
+  <nav class="sticky top-0 z-50 bg-gray-200 dark:bg-gray-800 text-sm">
+    <div class="relative flex items-center p-4 sm:hidden">
+      <button id="menu-toggle" aria-label="Abrir men\u00fa" class="mr-2">
+        <svg id="icon-open" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5m-16.5 5.25h16.5m-16.5 5.25h16.5" />
+        </svg>
+        <svg id="icon-close" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 hidden">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2">
+        <img src="/logo.png" alt="Logo" class="h-10 w-auto object-contain" />
+      </a>
+      <div class="ml-auto">
+        <a href="/login" class="px-4 py-2 rounded bg-gray-300 text-gray-800 hover:bg-gray-400">Ingresar</a>
+      </div>
+    </div>
+    <div id="menu" class="hidden sm:flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 border-t sm:border-none">
+      <a href="/" class="hidden sm:block mr-4">
+        <img src="/logo.png" alt="Logo" class="h-10 w-auto object-contain" />
+      </a>
+      <a href="/" class="block">Home</a>
+      <a href="/cursos" class="block">Cursos</a>
+      <a href="/nosotros" class="block">Nosotros</a>
+      <a href="/foro" class="block">Foro</a>
+      <div class="hidden sm:flex sm:ml-auto flex-col sm:flex-row items-start sm:items-center gap-2 w-full sm:w-auto">
+        <a href="/login" class="px-4 py-2 rounded min-w-[6rem] bg-gray-300 text-gray-800 hover:bg-gray-400">Ingresar</a>
+      </div>
+    </div>
+  </nav>
+  <main class="container mx-auto flex-grow flex flex-col items-center justify-center gap-4 p-4 text-center">
+    <h1 class="text-4xl font-bold">Ocurri\u00f3 un error</h1>
+    <p class="text-lg">Intenta nuevamente m\u00e1s tarde.</p>
+    <button id="home-btn" class="min-w-[8rem] px-4 py-2 rounded text-base font-medium bg-blue-600 text-white hover:bg-blue-700">Volver al inicio</button>
+  </main>
+  <footer class="bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200 text-sm">
+    <div class="container mx-auto px-4 py-8 grid gap-8 md:grid-cols-4">
+      <div>
+        <img src="/logo.png" alt="Logo" class="h-16 w-auto mb-2 object-contain" />
+        <p>Aula Digital Ciudadana es una plataforma de formaci\u00f3n en l\u00ednea para que aprendas a tu propio ritmo.</p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Contacto</h3>
+        <ul class="space-y-1">
+          <li>correo@example.com</li>
+          <li>Av. Siempre Viva 123</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Qui\u00e9nes somos</h3>
+        <p>Somos desarrolladores apasionados por compartir conocimiento a trav\u00e9s de cursos as\u00edncronos.</p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">Mapa del sitio</h3>
+        <ul class="space-y-1">
+          <li><a href="/">Home</a></li>
+          <li><a href="/cursos">Cursos</a></li>
+          <li><a href="/nosotros">Nosotros</a></li>
+          <li><a href="/foro">Foro</a></li>
+          <li><a href="/dashboard">Mi cuenta</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="text-center py-4 bg-gray-300 dark:bg-gray-900">© 2025 Aula Digital Ciudadana</div>
+  </footer>
   <script>
-    document.getElementById('home-btn').addEventListener('click', function() {
+    document.getElementById('home-btn').addEventListener('click', function () {
       window.location.href = '/';
+    });
+    const menuToggle = document.getElementById('menu-toggle');
+    const menu = document.getElementById('menu');
+    const iconOpen = document.getElementById('icon-open');
+    const iconClose = document.getElementById('icon-close');
+    menuToggle.addEventListener('click', function () {
+      menu.classList.toggle('hidden');
+      iconOpen.classList.toggle('hidden');
+      iconClose.classList.toggle('hidden');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- include Tailwind CSS on `error-standalone.html`
- add navigation bar markup and menu toggle script
- add footer markup matching the app styles

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686067c88fec832fade33c4293e98c97