### PR TITLE
Update success screen colors

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -69,7 +69,7 @@ export default function Navbar() {
                 <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 border rounded shadow flex flex-col z-10">
                   <Link
                     to="/dashboard"
-                    className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
+                    className="px-4 py-2 rounded bg-sky-500 text-white hover:bg-sky-600"
                     onClick={() => {
                       setOpen(false)
                       setDropdownOpen(false)
@@ -162,7 +162,7 @@ export default function Navbar() {
                 <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 border rounded shadow flex flex-col z-10">
                   <Link
                     to="/dashboard"
-                    className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
+                    className="px-4 py-2 rounded bg-sky-500 text-white hover:bg-sky-600"
                     onClick={() => {
                       setOpen(false)
                       setDropdownOpen(false)

--- a/src/pages/InscriptionSuccess.tsx
+++ b/src/pages/InscriptionSuccess.tsx
@@ -17,10 +17,10 @@ export default function InscriptionSuccess() {
         <h1 className="text-4xl font-bold">¡Te inscribiste al curso con éxito!</h1>
         <p className="text-xl">{courseName}</p>
         <div className="flex gap-4 mt-4">
-          <Button className="bg-green-600 hover:bg-green-700 text-white" onClick={() => navigate('/dashboard')}>
-            Ir al Dashboard
+          <Button className="bg-sky-500 hover:bg-sky-600 text-white" onClick={() => navigate('/dashboard')}>
+            Ir a mi cuenta
           </Button>
-          <Button className="bg-purple-600 hover:bg-purple-700 text-white" onClick={() => navigate('/cursos')}>
+          <Button className="bg-gray-500 hover:bg-gray-600 text-white" onClick={() => navigate('/cursos')}>
             Volver a Cursos
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- change text/color for success screen buttons
- set same color for "Mi cuenta" links in navbar

## Testing
- `pnpm lint` *(fails: cannot find package '@eslint/js')*
- `pnpm build` *(fails: several TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68630a3dea90832fbb5ef35d3ae77402