### PR TITLE
Improve default class generation

### DIFF
--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -40,6 +40,7 @@ const defaultClasses: ClassInfo[] = [
   },
 ]
 
+
 export interface CourseInfo {
   id: string
   title: string
@@ -788,3 +789,22 @@ Medirás resultados con herramientas analíticas y adaptarás las acciones segú
     ],
   },
 ]
+
+function createDefaultClasses(moduleTitle: string): ClassInfo[] {
+  return [
+    { ...defaultClasses[0], title: `Introducci\u00f3n a ${moduleTitle}` },
+    {
+      ...defaultClasses[1],
+      title: `Material complementario de ${moduleTitle}`,
+    },
+    { ...defaultClasses[2], title: `Evaluaci\u00f3n de ${moduleTitle}` },
+  ]
+}
+
+for (const course of courses) {
+  for (const module of course.modules) {
+    if (module.classes === defaultClasses) {
+      module.classes = createDefaultClasses(module.title)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a helper to generate class titles based on each module
- automatically replace placeholder classes after loading courses

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6863115c5524832f98411d42d98b44d8