### PR TITLE
Update dashboard visual layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@heroicons/react": "^2.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "6",
     "recharts": "^2.15.4",
     "zustand": "^5.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.1.0)
       react-router-dom:
         specifier: '6'
         version: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1298,6 +1301,11 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2718,6 +2726,10 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-icons@5.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -49,6 +49,7 @@ export interface CourseInfo {
   image: string
   duration: string
   level: string
+  free: boolean
   /** Recommended duration in weeks */
   weeks: number
   prerequisites?: {
@@ -69,6 +70,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-html-css.png',
     duration: '4 semanas',
     level: 'Principiante',
+    free: true,
     weeks: 4,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino']
@@ -165,6 +167,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-js.png',
     duration: '5 semanas',
     level: 'Principiante',
+    free: true,
     weeks: 5,
     prerequisites: {
       courses: ['html-css'],
@@ -240,6 +243,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react.png',
     duration: '8 semanas',
     level: 'Intermedio',
+    free: false,
     weeks: 8,
     prerequisites: {
       courses: ['javascript-basico'],
@@ -302,6 +306,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-node.png',
     duration: '8 semanas',
     level: 'Intermedio',
+    free: false,
     weeks: 8,
     prerequisites: {
       courses: ['javascript-basico'],
@@ -364,6 +369,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-ts.png',
     duration: '12 semanas',
     level: 'Avanzado',
+    free: false,
     weeks: 12,
     prerequisites: {
       courses: ['javascript-basico'],
@@ -444,6 +450,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-mern.png',
     duration: '12 semanas',
     level: 'Avanzado',
+    free: false,
     weeks: 12,
     prerequisites: {
       courses: ['react-principiantes', 'node-express'],
@@ -524,6 +531,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-jest.png',
     duration: '8 semanas',
     level: 'Intermedio',
+    free: true,
     weeks: 8,
     prerequisites: {
       courses: ['javascript-basico'],
@@ -586,6 +594,7 @@ export const courses: CourseInfo[] = [
     image: '/images/course-react-native.png',
     duration: '8 semanas',
     level: 'Intermedio',
+    free: false,
     weeks: 8,
     prerequisites: {
       courses: ['react-principiantes'],
@@ -659,6 +668,7 @@ Explorarás las colecciones, las funciones y los módulos integrados para automa
     image: '/images/course-python.png',
     duration: '6 semanas',
     level: 'Principiante',
+    free: true,
     weeks: 6,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino'],
@@ -682,6 +692,7 @@ A través de ejercicios de observación y prototipado crearás flujos de navegac
     image: '/images/course-ux.png',
     duration: '5 semanas',
     level: 'Principiante',
+    free: false,
     weeks: 5,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino'],
@@ -705,6 +716,7 @@ Implementarás pipelines automáticos que prueban y publican aplicaciones en con
     image: '/images/course-docker.png',
     duration: '6 semanas',
     level: 'Intermedio',
+    free: false,
     weeks: 6,
     prerequisites: {
       courses: ['javascript-basico'],
@@ -729,6 +741,7 @@ Trabajarás con hojas de cálculo, lenguajes de consulta y visualización intera
     image: '/images/course-data.png',
     duration: '7 semanas',
     level: 'Intermedio',
+    free: false,
     weeks: 7,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino'],
@@ -752,6 +765,7 @@ Mediante ejercicios guiados configurarás herramientas de escaneo y simulaciones
     image: '/images/course-security.png',
     duration: '8 semanas',
     level: 'Avanzado',
+    free: false,
     weeks: 8,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino'],
@@ -775,6 +789,7 @@ Medirás resultados con herramientas analíticas y adaptarás las acciones segú
     image: '/images/course-marketing.png',
     duration: '5 semanas',
     level: 'Intermedio',
+    free: true,
     weeks: 5,
     prerequisites: {
       other: ['Ser mayor de 18 años', 'DNI argentino'],

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 import Button from '../components/Button'
 import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { SiSpringboot, SiGithub, SiMysql } from 'react-icons/si'
 import { useAuthStore } from '../store/auth'
 import { Link, useNavigate } from 'react-router-dom'
 import { courses } from '../data/courses'
@@ -88,15 +89,27 @@ export default function Dashboard() {
                             className="border p-4 rounded shadow flex flex-col items-center gap-2 w-[300px] overflow-hidden"
                           >
                             {info?.image && (
-                              <img
-                                src={info.image}
-                                alt={course.title}
-                                className="w-full h-48 object-cover rounded"
-                              />
+                              <div className="relative w-full">
+                                <img
+                                  src={info.image}
+                                  alt={course.title}
+                                  className="w-full h-48 object-cover rounded"
+                                />
+                                <span
+                                  className={`absolute top-2 left-2 px-2 py-1 rounded text-xs font-bold text-white ${info.free ? 'bg-green-600' : 'bg-orange-600'}`}
+                                >
+                                  {info.free ? 'GRATIS' : 'PAGO'}
+                                </span>
+                              </div>
                             )}
                             <h2 className="text-xl font-semibold text-center w-full">
                               {course.title}
                             </h2>
+                            <div className="flex gap-2 text-2xl text-gray-700">
+                              <SiSpringboot />
+                              <SiGithub />
+                              <SiMysql />
+                            </div>
                             <PieChart width={120} height={120}>
                               <Pie
                                 data={data}
@@ -146,15 +159,27 @@ export default function Dashboard() {
                             className="border p-4 rounded shadow flex flex-col gap-2 w-[300px]"
                           >
                             {info?.image && (
-                              <img
-                                src={info.image}
-                                alt={course.title}
-                                className="w-full h-48 object-cover rounded"
-                              />
+                              <div className="relative w-full">
+                                <img
+                                  src={info.image}
+                                  alt={course.title}
+                                  className="w-full h-48 object-cover rounded"
+                                />
+                                <span
+                                  className={`absolute top-2 left-2 px-2 py-1 rounded text-xs font-bold text-white ${info.free ? 'bg-green-600' : 'bg-orange-600'}`}
+                                >
+                                  {info.free ? 'GRATIS' : 'PAGO'}
+                                </span>
+                              </div>
                             )}
                             <h2 className="text-xl font-semibold text-center w-full">
                               {course.title}
                             </h2>
+                            <div className="flex gap-2 text-2xl text-gray-700">
+                              <SiSpringboot />
+                              <SiGithub />
+                              <SiMysql />
+                            </div>
                             <p className="text-center font-semibold">
                               Nota:{' '}
                               {course.grade !== undefined
@@ -192,13 +217,25 @@ export default function Dashboard() {
               </>
             )}
           </div>
-          <div className="border border-black rounded p-4">
+          <div className="border border-black rounded p-4 space-y-2">
             <h1 className="text-3xl font-bold">Mis calificaciones</h1>
             <p>Próximamente</p>
+            <Button>Ver todos mis calificaciones</Button>
           </div>
-          <div className="border border-black rounded p-4">
+          <div className="border border-black rounded p-4 space-y-2">
             <h1 className="text-3xl font-bold">Mis certificados</h1>
             <p>Próximamente</p>
+            <Button>Ver todos mis certificados</Button>
+          </div>
+          <div className="border border-black rounded p-4 space-y-2">
+            <h1 className="text-3xl font-bold">Mis logros</h1>
+            <p>Próximamente</p>
+            <Button>Ver todos mis logros</Button>
+          </div>
+          <div className="border border-black rounded p-4 space-y-2">
+            <h1 className="text-3xl font-bold">Mis membresías</h1>
+            <p>Próximamente</p>
+            <Button>Ver todos mis membresías</Button>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- show course price tags and tech icons on dashboard cards
- add placeholder sections for achievements and memberships
- expose new `free` field in course data
- install `react-icons` dependency

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863135adf34832f885d1a32ba9f40d6