### PR TITLE
Implement responsive side menu on dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,12 +6,15 @@ import { SiSpringboot, SiGithub, SiMysql } from 'react-icons/si'
 import { useAuthStore } from '../store/auth'
 import { Link, useNavigate } from 'react-router-dom'
 import { courses } from '../data/courses'
-import getNextClassLink from "../utils/getNextClassLink"
+import getNextClassLink from '../utils/getNextClassLink'
+import { useState } from 'react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid'
 
 export default function Dashboard() {
   const enrolledCourses = useAuthStore(state => state.enrolledCourses)
   const logout = useAuthStore(state => state.logout)
   const navigate = useNavigate()
+  const [menuOpen, setMenuOpen] = useState(false)
   const currentCourses = enrolledCourses.filter(c => c.completed < c.total)
   const finishedCourses = enrolledCourses.filter(c => c.completed >= c.total)
 
@@ -23,39 +26,65 @@ export default function Dashboard() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex p-4 gap-4">
-        <aside className="w-56">
+      <main className="container mx-auto flex-grow flex p-4 gap-4 relative">
+        {menuOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 md:hidden"
+            onClick={() => setMenuOpen(false)}
+          />
+        )}
+        <button
+          onClick={() => setMenuOpen(true)}
+          aria-label="Abrir menú"
+          className="md:hidden p-2"
+        >
+          <Bars3Icon className="w-6 h-6" />
+        </button>
+        <aside
+          className={`w-56 bg-white dark:bg-gray-800 p-4 z-20 transform transition-transform fixed inset-y-0 left-0 md:static md:translate-x-0 ${menuOpen ? 'translate-x-0' : '-translate-x-full'} md:block`}
+        >
+          <button
+            onClick={() => setMenuOpen(false)}
+            aria-label="Cerrar menú"
+            className="md:hidden mb-2"
+          >
+            <XMarkIcon className="w-6 h-6" />
+          </button>
           <ul className="space-y-2">
             <li>
               <span className="block px-4 py-2 font-semibold">Menú</span>
             </li>
             <li>
-              <button className="w-full text-left px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">
+              <button className="w-full text-left px-4 py-2 rounded hover:bg-gray-100" onClick={() => setMenuOpen(false)}>
                 Mis cursos
               </button>
             </li>
             <li>
-              <button className="w-full text-left px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">
+              <button className="w-full text-left px-4 py-2 rounded hover:bg-gray-100" onClick={() => setMenuOpen(false)}>
                 Mis calificaciones
               </button>
             </li>
             <li>
-              <button className="w-full text-left px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">
+              <button className="w-full text-left px-4 py-2 rounded hover:bg-gray-100" onClick={() => setMenuOpen(false)}>
                 Mis certificados
               </button>
             </li>
             <li>
               <Link
                 to="/perfil"
-                className="block w-full text-left px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+                className="block w-full text-left px-4 py-2 rounded hover:bg-gray-100"
+                onClick={() => setMenuOpen(false)}
               >
                 Editar cuenta
               </Link>
             </li>
             <li>
               <button
-                onClick={handleLogout}
-                className="w-full text-left px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+                onClick={() => {
+                  setMenuOpen(false)
+                  handleLogout()
+                }}
+                className="w-full text-left px-4 py-2 rounded hover:bg-gray-100"
               >
                 Cerrar sesión
               </button>


### PR DESCRIPTION
## Summary
- add state and icons for responsive side menu
- implement collapsible menu overlay for small screens
- style dashboard menu items without default background

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68631a0fca30832fb2730a0b9d3b201a