### PR TITLE
Fix course card layout

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
-import Button from '../components/Button'
 import CourseCard from '../components/CourseCard'
 import { useAuthStore } from '../store/auth'
 import { Link, useNavigate } from 'react-router-dom'

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -80,7 +80,7 @@ export default function Home() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
             </button>
-            <div className="grid grid-flow-col auto-cols-[minmax(300px,1fr)] gap-4 overflow-hidden flex-grow">
+            <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
               {pageCourses.map(course => (
                 <CourseCard
                   key={course.id}


### PR DESCRIPTION
## Summary
- adjust `Cursos Destacados` carousel grid to wrap items
- remove unused import in Dashboard
- run formatter and lint

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686322bc594c832fbe67c295e750b591