### PR TITLE
Implement full-screen slider on home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "6",
     "recharts": "^2.15.4",
+    "swiper": "^11.2.10",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       recharts:
         specifier: ^2.15.4
         version: 2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      swiper:
+        specifier: ^11.2.10
+        version: 11.2.10
       zustand:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@19.1.8)(react@19.1.0)
@@ -1444,6 +1447,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swiper@11.2.10:
+    resolution: {integrity: sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==}
+    engines: {node: '>= 4.7.0'}
 
   tailwindcss@3.4.1:
     resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}
@@ -2886,6 +2893,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swiper@11.2.10: {}
 
   tailwindcss@3.4.1:
     dependencies:

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,16 +4,17 @@ import Button from '../components/Button'
 import CourseCard from '../components/CourseCard'
 import { courses } from '../data/courses'
 import { Link } from 'react-router-dom'
-import { useState } from 'react'
+import { useRef } from 'react'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Navigation } from 'swiper/modules'
+import 'swiper/css'
+import 'swiper/css/navigation'
 import { UserCircleIcon } from '@heroicons/react/24/solid'
 
 export default function Home() {
   const featuredCourses = courses.slice(0, 5)
-  const [index, setIndex] = useState(0)
-  const itemsPerPage = 3
-  const pageCourses = Array.from({ length: itemsPerPage }).map((_, i) =>
-    featuredCourses[(index + i) % featuredCourses.length],
-  )
+  const prevRef = useRef<HTMLButtonElement>(null)
+  const nextRef = useRef<HTMLButtonElement>(null)
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -68,41 +69,47 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="container mx-auto py-12 flex flex-col gap-4 items-center">
-          <h2 className="text-2xl font-bold">Cursos Destacados</h2>
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => setIndex((index - 1 + featuredCourses.length) % featuredCourses.length)}
-              className="p-2"
-              aria-label="Anterior"
-            >
+        <section className="relative h-screen w-screen flex flex-col items-center justify-center">
+          <h2 className="text-2xl font-bold mb-2">Cursos Destacados</h2>
+          <div className="absolute top-2 left-1/2 -translate-x-1/2 flex gap-4 z-10">
+            <button ref={prevRef} className="p-2 bg-white/80 rounded" aria-label="Anterior">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
               </svg>
             </button>
-            <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
-              {pageCourses.map(course => (
-                <CourseCard
-                  key={course.id}
-                  id={course.id}
-                  title={course.title}
-                  weeks={course.weeks}
-                  level={course.level}
-                  image={course.image}
-                  showProgress={false}
-                />
-              ))}
-            </div>
-            <button
-              onClick={() => setIndex((index + 1) % featuredCourses.length)}
-              className="p-2"
-              aria-label="Siguiente"
-            >
+            <button ref={nextRef} className="p-2 bg-white/80 rounded" aria-label="Siguiente">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
               </svg>
             </button>
           </div>
+          <Swiper
+            modules={[Navigation]}
+            loop
+            navigation={{ prevEl: prevRef.current, nextEl: nextRef.current }}
+            onBeforeInit={swiper => {
+              if (typeof swiper.params.navigation !== 'boolean') {
+                swiper.params.navigation!.prevEl = prevRef.current
+                swiper.params.navigation!.nextEl = nextRef.current
+              }
+            }}
+            className="w-full h-full"
+          >
+            {featuredCourses.map(course => (
+              <SwiperSlide key={course.id} className="flex items-center justify-center">
+                <div className="max-w-md w-full px-4">
+                  <CourseCard
+                    id={course.id}
+                    title={course.title}
+                    weeks={course.weeks}
+                    level={course.level}
+                    image={course.image}
+                    showProgress={false}
+                  />
+                </div>
+              </SwiperSlide>
+            ))}
+          </Swiper>
         </section>
 
         <section className="container mx-auto py-12 flex flex-col items-center gap-6">

--- a/src/types/swiper-css.d.ts
+++ b/src/types/swiper-css.d.ts
@@ -1,0 +1,2 @@
+declare module 'swiper/css';
+declare module 'swiper/css/navigation';


### PR DESCRIPTION
## Summary
- add `swiper` dependency
- integrate Swiper in Home page for a looping slider
- place navigation buttons at the top
- declare TypeScript modules for Swiper CSS imports

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6863253af5b4832fb9e4c2b09a335b79