### PR TITLE
Add course slider to dashboard

### DIFF
--- a/src/components/CourseSlider.tsx
+++ b/src/components/CourseSlider.tsx
@@ -1,0 +1,109 @@
+import { useRef, useEffect } from 'react'
+import type { Swiper as SwiperType } from 'swiper'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Navigation } from 'swiper/modules'
+import 'swiper/css'
+import 'swiper/css/navigation'
+import CourseCard from './CourseCard'
+
+interface Course {
+  id: string
+  title: string
+  weeks: number
+  level: string
+  image: string
+}
+
+interface Props {
+  courses: Course[]
+  showProgress?: boolean
+}
+
+export default function CourseSlider({ courses, showProgress = true }: Props) {
+  const prevRef = useRef<HTMLButtonElement>(null)
+  const nextRef = useRef<HTMLButtonElement>(null)
+  const swiperRef = useRef<SwiperType | null>(null)
+
+  useEffect(() => {
+    const swiper = swiperRef.current
+    if (!swiper || !prevRef.current || !nextRef.current) return
+    if (swiper.params.navigation && typeof swiper.params.navigation !== 'boolean') {
+      swiper.params.navigation.prevEl = prevRef.current
+      swiper.params.navigation.nextEl = nextRef.current
+    }
+    swiper.navigation.init()
+    swiper.navigation.update()
+  }, [])
+
+  return (
+    <div>
+      <Swiper
+        modules={[Navigation]}
+        loop
+        onSwiper={swiper => {
+          swiperRef.current = swiper
+        }}
+        slidesPerView={1}
+        spaceBetween={16}
+        breakpoints={{
+          768: { slidesPerView: 2, spaceBetween: 16 },
+          1280: { slidesPerView: 3, spaceBetween: 20 },
+        }}
+        className="w-full max-w-7xl mx-auto"
+      >
+        {courses.map(course => (
+          <SwiperSlide key={course.id} className="flex items-center justify-center">
+            <div className="max-w-md w-full px-4">
+              <CourseCard
+                id={course.id}
+                title={course.title}
+                weeks={course.weeks}
+                level={course.level}
+                image={course.image}
+                showProgress={showProgress}
+              />
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <div className="container mx-auto flex flex-col items-center mt-6 space-y-4">
+        <div className="flex gap-4">
+          <button
+            ref={prevRef}
+            className="flex items-center gap-1 px-3 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
+            aria-label="Anterior"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+            <span className="hidden sm:inline">Anterior</span>
+          </button>
+          <button
+            ref={nextRef}
+            className="flex items-center gap-1 px-3 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
+            aria-label="Siguiente"
+          >
+            <span className="hidden sm:inline">Siguiente</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
-import CourseCard from '../components/CourseCard'
+import CourseSlider from '../components/CourseSlider'
 import { useAuthStore } from '../store/auth'
 import { Link, useNavigate } from 'react-router-dom'
 import { courses } from '../data/courses'
@@ -73,41 +73,35 @@ export default function Dashboard() {
                 {currentCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Actualmente cursando</h2>
-                    <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
-                      {currentCourses.map(course => {
+                    <CourseSlider
+                      courses={currentCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
-                        return (
-                          <CourseCard
-                            key={course.id}
-                            id={course.id}
-                            title={info?.title ?? course.title}
-                            weeks={info?.weeks ?? 0}
-                            level={info?.level ?? ''}
-                            image={info?.image ?? ''}
-                          />
-                        )
+                        return {
+                          id: course.id,
+                          title: info?.title ?? course.title,
+                          weeks: info?.weeks ?? 0,
+                          level: info?.level ?? '',
+                          image: info?.image ?? '',
+                        }
                       })}
-                    </div>
+                    />
                   </div>
                 )}
                 {finishedCourses.length > 0 && (
                   <div className="space-y-2">
                     <h2 className="text-2xl font-semibold">Cursos finalizados</h2>
-                    <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
-                      {finishedCourses.map(course => {
+                    <CourseSlider
+                      courses={finishedCourses.map(course => {
                         const info = courses.find(c => c.id === course.id)
-                        return (
-                          <CourseCard
-                            key={course.id}
-                            id={course.id}
-                            title={info?.title ?? course.title}
-                            weeks={info?.weeks ?? 0}
-                            level={info?.level ?? ''}
-                            image={info?.image ?? ''}
-                          />
-                        )
+                        return {
+                          id: course.id,
+                          title: info?.title ?? course.title,
+                          weeks: info?.weeks ?? 0,
+                          level: info?.level ?? '',
+                          image: info?.image ?? '',
+                        }
                       })}
-                    </div>
+                    />
                   </div>
                 )}
               </>


### PR DESCRIPTION
## Summary
- create `CourseSlider` component replicating Home page slider logic
- update Dashboard to display current and completed courses using sliders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68632e91135c832faca9bf3ffa437532