### PR TITLE
Fix NotFound home button

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -19,7 +19,7 @@ export default function NotFound() {
             <p className="text-lg mb-6">
               Ups... Lo lamento, la ruta que estás buscando no existe.
             </p>
-            <Button onClick={() => navigate('/Home')}>Volver al inicio</Button>
+            <Button onClick={() => navigate('/')}>Volver al inicio</Button>
           </div>
 
           <img


### PR DESCRIPTION
## Summary
- fix navigation path on `NotFound` page so "Volver al inicio" works

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863481395d4832faaffa16b448e4ada