### PR TITLE
Update featured courses buttons

### DIFF
--- a/html/home.html
+++ b/html/home.html
@@ -79,7 +79,20 @@
               <h3 class="text-xl font-semibold">HTML y CSS desde cero</h3>
               <p>Duración: 4 semanas</p>
               <p>Nivel: Principiante</p>
-              <a href="#" class="mt-2 px-4 py-2 rounded bg-indigo-500 text-white text-center">Ver info</a>
+              <div class="mt-2 flex flex-col sm:flex-row gap-2 justify-center">
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-indigo-500 text-white hover:bg-indigo-600 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Ver info</span>
+                </a>
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-blue-600 text-white hover:bg-blue-700 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm14.024-.983a1.125 1.125 0 0 1 0 1.966l-5.603 3.113A1.125 1.125 0 0 1 9 15.113V8.887c0-.857.921-1.4 1.671-.983l5.603 3.113Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Comenzar</span>
+                </a>
+              </div>
             </div>
           </div>
           <div class="swiper-slide flex justify-center">
@@ -88,7 +101,20 @@
               <h3 class="text-xl font-semibold">JavaScript desde cero</h3>
               <p>Duración: 5 semanas</p>
               <p>Nivel: Principiante</p>
-              <a href="#" class="mt-2 px-4 py-2 rounded bg-indigo-500 text-white text-center">Ver info</a>
+              <div class="mt-2 flex flex-col sm:flex-row gap-2 justify-center">
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-indigo-500 text-white hover:bg-indigo-600 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Ver info</span>
+                </a>
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-blue-600 text-white hover:bg-blue-700 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm14.024-.983a1.125 1.125 0 0 1 0 1.966l-5.603 3.113A1.125 1.125 0 0 1 9 15.113V8.887c0-.857.921-1.4 1.671-.983l5.603 3.113Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Comenzar</span>
+                </a>
+              </div>
             </div>
           </div>
           <div class="swiper-slide flex justify-center">
@@ -97,7 +123,20 @@
               <h3 class="text-xl font-semibold">React para principiantes</h3>
               <p>Duración: 8 semanas</p>
               <p>Nivel: Intermedio</p>
-              <a href="#" class="mt-2 px-4 py-2 rounded bg-indigo-500 text-white text-center">Ver info</a>
+              <div class="mt-2 flex flex-col sm:flex-row gap-2 justify-center">
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-indigo-500 text-white hover:bg-indigo-600 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Ver info</span>
+                </a>
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-blue-600 text-white hover:bg-blue-700 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm14.024-.983a1.125 1.125 0 0 1 0 1.966l-5.603 3.113A1.125 1.125 0 0 1 9 15.113V8.887c0-.857.921-1.4 1.671-.983l5.603 3.113Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Comenzar</span>
+                </a>
+              </div>
             </div>
           </div>
           <div class="swiper-slide flex justify-center">
@@ -106,7 +145,20 @@
               <h3 class="text-xl font-semibold">Node.js y Express</h3>
               <p>Duración: 8 semanas</p>
               <p>Nivel: Intermedio</p>
-              <a href="#" class="mt-2 px-4 py-2 rounded bg-indigo-500 text-white text-center">Ver info</a>
+              <div class="mt-2 flex flex-col sm:flex-row gap-2 justify-center">
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-indigo-500 text-white hover:bg-indigo-600 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Ver info</span>
+                </a>
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-blue-600 text-white hover:bg-blue-700 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm14.024-.983a1.125 1.125 0 0 1 0 1.966l-5.603 3.113A1.125 1.125 0 0 1 9 15.113V8.887c0-.857.921-1.4 1.671-.983l5.603 3.113Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Comenzar</span>
+                </a>
+              </div>
             </div>
           </div>
           <div class="swiper-slide flex justify-center">
@@ -115,7 +167,20 @@
               <h3 class="text-xl font-semibold">TypeScript avanzado</h3>
               <p>Duración: 12 semanas</p>
               <p>Nivel: Avanzado</p>
-              <a href="#" class="mt-2 px-4 py-2 rounded bg-indigo-500 text-white text-center">Ver info</a>
+              <div class="mt-2 flex flex-col sm:flex-row gap-2 justify-center">
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-indigo-500 text-white hover:bg-indigo-600 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Ver info</span>
+                </a>
+                <a href="#" class="flex w-full sm:flex-1 items-center justify-center gap-2 px-4 py-2 text-base rounded bg-blue-600 text-white hover:bg-blue-700 min-w-[8rem] uppercase">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+                    <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm14.024-.983a1.125 1.125 0 0 1 0 1.966l-5.603 3.113A1.125 1.125 0 0 1 9 15.113V8.887c0-.857.921-1.4 1.671-.983l5.603 3.113Z" clip-rule="evenodd"/>
+                  </svg>
+                  <span>Comenzar</span>
+                </a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update the **Cursos Destacados** slider so each course card has two buttons just like the main courses page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68636182c810832f8f06378794334b5b