### PR TITLE
Ajustar tarjetas a 360px

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -52,7 +52,7 @@ export default function CourseCard({
 
   return (
     <div
-      className="border border-gray-300 p-card rounded-card shadow-card flex flex-col h-full gap-4"
+      className="border border-gray-300 p-card rounded-card shadow-card flex flex-col h-full gap-4 w-[360px] min-h-[420px]"
     >
       <Link to={`/cursos/${id}`} className="flex flex-col gap-2 flex-grow">
         <img

--- a/src/components/CourseSlider.tsx
+++ b/src/components/CourseSlider.tsx
@@ -53,7 +53,7 @@ export default function CourseSlider({ courses, showProgress = true }: Props) {
       >
         {courses.map(course => (
           <SwiperSlide key={course.id} className="flex items-center justify-center">
-            <div className="max-w-md w-full px-4">
+            <div className="w-[360px] px-4">
               <CourseCard
                 id={course.id}
                 title={course.title}

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-6 items-start grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">
+              <div className="grid gap-6 items-start grid-cols-[repeat(auto-fill,minmax(360px,1fr))]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-6 items-start grid-cols-[repeat(auto-fill,minmax(260px,1fr))]">
+          <div className="grid gap-6 items-start grid-cols-[repeat(auto-fill,minmax(360px,1fr))]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -60,7 +60,7 @@ export default function Home() {
 
         <section className="py-12">
           <h2 className="text-2xl font-bold text-center mb-4">Cursos Destacados</h2>
-          <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(300px,_1fr))]">
+          <div className="grid gap-4 justify-center [grid-template-columns:repeat(auto-fit,_minmax(360px,_1fr))]">
             {featuredCourses.slice(0,4).map(course => (
               <CourseCard key={course.id} {...course} showProgress={false} />
             ))}


### PR DESCRIPTION
## Summary
- limite fijo de ancho y alto para `CourseCard`
- ajustar contenedor de `CourseSlider`
- actualizar grillas en `Courses` y `Home`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b32ba5e30832f8e1ddf9eae6e8230