### PR TITLE
Set base path for subfolder deployment

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import ScrollToTop from './components/ScrollToTop'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/curso-webapp">
       <ScrollToTop />
       <App />
     </BrowserRouter>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: '/curso-webapp/',
   server: {
     host: true, // Muy importante: escucha en todas las interfaces
-    allowedHosts: ['earaoz.dyndns.org'],
+    allowedHosts: ['earaoz.dyndns.org', 'localhost'],
   },
 })
+


### PR DESCRIPTION
## Summary
- configure Vite to serve from `/curso-webapp/`
- allow localhost host in dev server
- set React Router basename for new base path

## Testing
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686b447c8dbc832fb57e9fd19dba403a