### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { UserCircleIcon } from '@heroicons/react/24/solid'
 import DarkModeToggle from './DarkModeToggle'
@@ -12,6 +12,7 @@ export default function Navbar() {
   const logout = useAuthStore(state => state.logout)
   const [open, setOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
   const exampleUser = { name: 'Mariana' }
   const name = (user as { name?: string } | null)?.name ?? exampleUser.name
 
@@ -25,10 +26,29 @@ export default function Navbar() {
   const toggleMenu = () => setOpen(!open)
   const toggleDropdown = () => setDropdownOpen(!dropdownOpen)
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setDropdownOpen(false)
+      }
+    }
+
+    if (dropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [dropdownOpen])
+
   return (
     <nav className="sticky top-0 z-50 bg-blue-600 dark:bg-blue-700 text-white text-lg py-6">
       <div className="container mx-auto px-4">
-        <div className="grid grid-cols-3 items-center py-5 sm:hidden">
+        <div className="grid grid-cols-[auto_1fr_auto] items-center py-5 sm:hidden">
         <button
           onClick={toggleMenu}
           aria-label="Abrir menú"
@@ -37,11 +57,11 @@ export default function Navbar() {
           tabIndex={0}
         >
           {open ? (
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-8 h-8">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5m-16.5 5.25h16.5m-16.5 5.25h16.5" />
             </svg>
           )}
@@ -55,7 +75,7 @@ export default function Navbar() {
         </Link>
         <div className="justify-self-end">
           {isLogged ? (
-            <div className="relative">
+            <div className="relative" ref={dropdownRef}>
               <button
                 onClick={toggleDropdown}
                 className="flex items-center gap-2 px-4 py-2 rounded bg-tertiary text-white hover:brightness-90 focus:outline-none focus:ring-2 focus:ring-primary"
@@ -153,7 +173,7 @@ export default function Navbar() {
         </NavLink>
         <div className="hidden sm:flex sm:ml-auto flex-col sm:flex-row items-start sm:items-center gap-2 w-full sm:w-auto">
           {isLogged ? (
-            <div className="relative w-full sm:w-auto">
+            <div className="relative w-full sm:w-auto" ref={dropdownRef}>
               <button
                 onClick={toggleDropdown}
                 className="flex items-center gap-2 w-full sm:w-auto px-4 py-2 rounded bg-tertiary text-white hover:brightness-90 focus:outline-none focus:ring-2 focus:ring-primary"

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -48,7 +48,7 @@ export default function Courses() {
             {inProgressCourses.length === 0 ? (
               <p>No tienes cursos en curso.</p>
             ) : (
-              <div className="grid gap-6 items-start justify-start grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
+              <div className="grid gap-6 items-start justify-center sm:justify-start grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
                 {inProgressCourses.map(course => {
                   const info = courses.find(c => c.id === course.id)
                   return (
@@ -119,7 +119,7 @@ export default function Courses() {
               </label>
             )}
           </div>
-          <div className="grid gap-6 items-start justify-start grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
+          <div className="grid gap-6 items-start justify-center sm:justify-start grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
             {filteredCourses.map(course => (
               <CourseCard
                 key={course.id}


### PR DESCRIPTION
## Summary
- center the logo in mobile navbar
- enlarge hamburger icon
- close user menu on click outside
- center course cards on mobile

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686bd3af9a80832f81f936cc928b33ec