### PR TITLE
Visual tweaks for navbar, hero background, and footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,20 +11,20 @@ export default function Footer() {
             Aula Digital Ciudadana es una plataforma de formación en línea para que aprendas a tu propio ritmo.
           </p>
         </div>
-        <div>
+        <div className="text-lg">
           <h3 className="font-semibold mb-2">Contacto</h3>
           <ul className="space-y-1">
             <li>correo@example.com</li>
             <li>Av. Siempre Viva 123</li>
           </ul>
         </div>
-        <div>
+        <div className="text-lg">
           <h3 className="font-semibold mb-2">Quiénes somos</h3>
           <p>
             Somos desarrolladores apasionados por compartir conocimiento a través de cursos asíncronos.
           </p>
         </div>
-        <div>
+        <div className="text-lg">
           <h3 className="font-semibold mb-2">Mapa del sitio</h3>
           <ul className="space-y-1">
             <li>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -49,7 +49,7 @@ export default function Navbar() {
   }, [dropdownOpen])
 
   return (
-    <nav className="sticky top-0 z-50 bg-blue-600 dark:bg-blue-700 text-white text-lg py-[21px]">
+    <nav className="sticky top-0 z-50 bg-blue-600 dark:bg-blue-700 text-white text-lg py-4">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-[auto_1fr_auto] items-center py-5 sm:hidden">
         <button

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,7 +23,12 @@ export default function Home() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
         <main className="flex-grow">
-          <section className="w-full bg-gradient-to-r from-blue-50 to-purple-50 dark:from-gray-800 dark:to-gray-700">
+          <section className="relative w-full bg-gradient-to-r from-blue-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 overflow-hidden">
+            <img
+              src={getAssetUrl('/images/hero.png')}
+              alt=""
+              className="absolute inset-0 w-full h-full object-cover blur-3xl scale-110 -z-10"
+            />
             <div className="container mx-auto flex flex-col-reverse md:flex-row items-center gap-8 p-8">
               <div className="flex flex-col items-start gap-4 md:w-1/2">
                 <h1 className="text-6xl md:text-7xl font-extrabold text-blue-600 pb-2">


### PR DESCRIPTION
## Summary
- reduce navigation bar vertical padding to shorten its height
- add blurred background image to the Home hero section
- enlarge footer link sections for better legibility

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bde815dd4832f8c9c00a38d871404