### PR TITLE
Fix hero background and equalize footer columns

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,28 +5,28 @@ export default function Footer() {
   return (
     <footer className="bg-gray-500 dark:bg-gray-900 text-white text-sm">
       <div className="container mx-auto px-4 py-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
-        <div className="flex flex-col items-center text-center">
+        <div className="flex flex-col items-center">
           <img src={getAssetUrl('/logo.png')} alt="Logo" className="h-16 w-auto mb-2 object-contain" />
-          <p>
+          <p className="text-left">
             Aula Digital Ciudadana es una plataforma de formación en línea para que aprendas a tu propio ritmo.
           </p>
         </div>
-        <div className="text-lg text-center">
-          <h3 className="font-semibold mb-2">Contacto</h3>
-          <ul className="space-y-1">
+        <div className="text-lg">
+          <h3 className="font-semibold mb-2 text-center">Contacto</h3>
+          <ul className="space-y-1 text-left">
             <li>correo@example.com</li>
             <li>Av. Siempre Viva 123</li>
           </ul>
         </div>
-        <div className="text-lg text-center">
-          <h3 className="font-semibold mb-2">Quiénes somos</h3>
-          <p>
+        <div className="text-lg">
+          <h3 className="font-semibold mb-2 text-center">Quiénes somos</h3>
+          <p className="text-left">
             Somos desarrolladores apasionados por compartir conocimiento a través de cursos asíncronos.
           </p>
         </div>
-        <div className="text-lg text-center">
-          <h3 className="font-semibold mb-2">Mapa del sitio</h3>
-          <ul className="space-y-1">
+        <div className="text-lg">
+          <h3 className="font-semibold mb-2 text-center">Mapa del sitio</h3>
+          <ul className="space-y-1 text-left">
             <li>
               <Link to="/">Home</Link>
             </li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import getAssetUrl from '../utils/getAssetUrl'
 export default function Footer() {
   return (
     <footer className="bg-gray-500 dark:bg-gray-900 text-white text-sm">
-      <div className="container mx-auto px-4 py-8 grid gap-8 md:grid-cols-4">
+      <div className="container mx-auto px-4 py-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
         <div>
           <img src={getAssetUrl('/logo.png')} alt="Logo" className="h-16 w-auto mb-2 object-contain" />
           <p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,26 +5,26 @@ export default function Footer() {
   return (
     <footer className="bg-gray-500 dark:bg-gray-900 text-white text-sm">
       <div className="container mx-auto px-4 py-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
-        <div>
+        <div className="flex flex-col items-center text-center">
           <img src={getAssetUrl('/logo.png')} alt="Logo" className="h-16 w-auto mb-2 object-contain" />
           <p>
             Aula Digital Ciudadana es una plataforma de formación en línea para que aprendas a tu propio ritmo.
           </p>
         </div>
-        <div className="text-lg">
+        <div className="text-lg text-center">
           <h3 className="font-semibold mb-2">Contacto</h3>
           <ul className="space-y-1">
             <li>correo@example.com</li>
             <li>Av. Siempre Viva 123</li>
           </ul>
         </div>
-        <div className="text-lg">
+        <div className="text-lg text-center">
           <h3 className="font-semibold mb-2">Quiénes somos</h3>
           <p>
             Somos desarrolladores apasionados por compartir conocimiento a través de cursos asíncronos.
           </p>
         </div>
-        <div className="text-lg">
+        <div className="text-lg text-center">
           <h3 className="font-semibold mb-2">Mapa del sitio</h3>
           <ul className="space-y-1">
             <li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,13 @@
 import { Link } from 'react-router-dom'
+import {
+  EnvelopeIcon,
+  MapPinIcon,
+  HomeIcon,
+  BookOpenIcon,
+  UsersIcon,
+  ChatBubbleLeftRightIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/solid'
 import getAssetUrl from '../utils/getAssetUrl'
 
 export default function Footer() {
@@ -14,8 +23,14 @@ export default function Footer() {
         <div className="text-lg">
           <h3 className="font-semibold mb-2 text-center">Contacto</h3>
           <ul className="space-y-1 text-left">
-            <li>correo@example.com</li>
-            <li>Av. Siempre Viva 123</li>
+            <li className="flex items-center gap-2">
+              <EnvelopeIcon className="w-5 h-5" />
+              <span>correo@example.com</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <MapPinIcon className="w-5 h-5" />
+              <span>Av. Siempre Viva 123</span>
+            </li>
           </ul>
         </div>
         <div className="text-lg">
@@ -27,19 +42,24 @@ export default function Footer() {
         <div className="text-lg">
           <h3 className="font-semibold mb-2 text-center">Mapa del sitio</h3>
           <ul className="space-y-1 text-left">
-            <li>
+            <li className="flex items-center gap-2">
+              <HomeIcon className="w-5 h-5" />
               <Link to="/">Home</Link>
             </li>
-            <li>
+            <li className="flex items-center gap-2">
+              <BookOpenIcon className="w-5 h-5" />
               <Link to="/cursos">Cursos</Link>
             </li>
-            <li>
+            <li className="flex items-center gap-2">
+              <UsersIcon className="w-5 h-5" />
               <Link to="/nosotros">Nosotros</Link>
             </li>
-            <li>
+            <li className="flex items-center gap-2">
+              <ChatBubbleLeftRightIcon className="w-5 h-5" />
               <Link to="/foro">Foro</Link>
             </li>
-            <li>
+            <li className="flex items-center gap-2">
+              <UserCircleIcon className="w-5 h-5" />
               <Link to="/dashboard">Mi cuenta</Link>
             </li>
           </ul>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,7 +24,7 @@ export default function Home() {
       <Navbar />
         <main className="flex-grow">
           <section
-            className="relative w-full bg-gradient-to-r from-blue-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 overflow-hidden"
+            className="relative w-full bg-gradient-to-r from-blue-50/80 to-purple-50/80 dark:from-gray-800/80 dark:to-gray-700/80 overflow-hidden"
           >
             <div
               className="absolute inset-0 w-full h-full bg-cover bg-center blur-3xl scale-110 -z-10"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,12 +24,10 @@ export default function Home() {
       <Navbar />
         <main className="flex-grow">
           <section
-            className="relative w-full bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 overflow-hidden"
+            className="relative w-full bg-cover bg-center overflow-hidden"
+            style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
           >
-            <div
-              className="absolute inset-0 w-full h-full bg-cover bg-center blur-sm scale-105 -z-10"
-              style={{ backgroundImage: `url('/images/hero.png')` }}
-            />
+            <div className="absolute inset-0 bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 backdrop-blur-sm -z-10" />
             <div className="container mx-auto flex flex-col-reverse md:flex-row items-center gap-8 p-8">
               <div className="flex flex-col items-start gap-4 md:w-1/2">
                 <h1 className="text-6xl md:text-7xl font-extrabold text-blue-600 pb-2">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,10 +23,11 @@ export default function Home() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
         <main className="flex-grow">
-          <section
-            className="relative w-full bg-cover bg-center overflow-hidden"
-            style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
-          >
+          <section className="relative w-full overflow-hidden">
+            <div
+              className="absolute inset-0 w-full h-full bg-cover bg-center blur-3xl scale-110 -z-10"
+              style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
+            />
             <div className="absolute inset-0 bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 backdrop-blur-sm -z-10" />
             <div className="container mx-auto flex flex-col-reverse md:flex-row items-center gap-8 p-8">
               <div className="flex flex-col items-start gap-4 md:w-1/2">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,7 +25,7 @@ export default function Home() {
         <main className="flex-grow">
           <section className="relative w-full overflow-hidden">
             <div
-              className="absolute inset-0 w-full h-full bg-cover bg-center blur-3xl scale-110 -z-10"
+              className="absolute inset-0 w-full h-full bg-cover bg-center blur-[32px] scale-110 -z-10"
               style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
             />
             <div className="absolute inset-0 bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 backdrop-blur-sm -z-10" />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,11 +24,11 @@ export default function Home() {
       <Navbar />
         <main className="flex-grow">
           <section
-            className="relative w-full bg-gradient-to-r from-blue-50/80 to-purple-50/80 dark:from-gray-800/80 dark:to-gray-700/80 overflow-hidden"
+            className="relative w-full bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 overflow-hidden"
           >
             <div
-              className="absolute inset-0 w-full h-full bg-cover bg-center blur-3xl scale-110 -z-10"
-              style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
+              className="absolute inset-0 w-full h-full bg-cover bg-center blur-sm scale-105 -z-10"
+              style={{ backgroundImage: `url('/images/hero.png')` }}
             />
             <div className="container mx-auto flex flex-col-reverse md:flex-row items-center gap-8 p-8">
               <div className="flex flex-col items-start gap-4 md:w-1/2">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,7 +25,7 @@ export default function Home() {
         <main className="flex-grow">
           <section className="relative w-full overflow-hidden">
             <div
-              className="absolute inset-0 w-full h-full bg-cover bg-center blur-[32px] scale-110 -z-10"
+              className="absolute inset-0 w-full h-full bg-cover bg-center blur-[48px] scale-110 -z-10"
               style={{ backgroundImage: `url(${getAssetUrl('/images/hero.png')})` }}
             />
             <div className="absolute inset-0 bg-gradient-to-r from-blue-50/70 to-purple-50/70 dark:from-gray-800/70 dark:to-gray-700/70 backdrop-blur-sm -z-10" />


### PR DESCRIPTION
## Summary
- ensure footer columns evenly distribute with a responsive grid
- tweak Home page hero gradient transparency so the background image appears

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c0804c1c4832fa067e52e408630df