### PR TITLE
Improve Home CTA & enrollment cards

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -145,7 +145,7 @@ export default function Navbar() {
         <NavLink
           to="/"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-yellow-300' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Home
@@ -153,7 +153,7 @@ export default function Navbar() {
         <NavLink
           to="/cursos"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-yellow-300' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Cursos
@@ -161,7 +161,7 @@ export default function Navbar() {
         <NavLink
           to="/nosotros"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-yellow-300' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Nosotros
@@ -169,7 +169,7 @@ export default function Navbar() {
         <NavLink
           to="/foro"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-yellow-300' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Foro

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -125,7 +125,7 @@ export default function Navbar() {
                 navigate('/login')
                 setOpen(false)
               }}
-              className="px-4 py-2 rounded bg-gray-300 text-gray-800 hover:bg-gray-400"
+              className="px-4 py-2 rounded bg-gray-300 text-gray-800 hover:bg-gray-400 uppercase"
             >
               Ingresar
             </button>
@@ -223,7 +223,7 @@ export default function Navbar() {
                 navigate('/login')
                 setOpen(false)
               }}
-              className="px-4 py-2 rounded min-w-[6rem] bg-gray-300 text-gray-800 hover:bg-gray-400"
+              className="px-4 py-2 rounded min-w-[6rem] bg-gray-300 text-gray-800 hover:bg-gray-400 uppercase"
             >
               Ingresar
             </button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -145,7 +145,7 @@ export default function Navbar() {
         <NavLink
           to="/"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Home
@@ -153,7 +153,7 @@ export default function Navbar() {
         <NavLink
           to="/cursos"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Cursos
@@ -161,7 +161,7 @@ export default function Navbar() {
         <NavLink
           to="/nosotros"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Nosotros
@@ -169,7 +169,7 @@ export default function Navbar() {
         <NavLink
           to="/foro"
           className={({ isActive }) =>
-            `block px-4 py-2 uppercase ${isActive ? 'font-semibold text-tertiary' : ''}`}
+            `block px-4 py-2 uppercase ${isActive ? 'text-tertiary' : ''}`}
           onClick={() => setOpen(false)}
         >
           Foro

--- a/src/pages/Class.tsx
+++ b/src/pages/Class.tsx
@@ -74,7 +74,7 @@ export default function ClassPage() {
     return (
       <div className="flex flex-col min-h-screen">
         <Navbar />
-        <main className="container mx-auto flex-grow p-4 flex flex-col items-center justify-center">
+        <main className="container mx-auto flex-grow p-4 pb-12 flex flex-col items-center justify-center">
           <p>Clase no encontrada</p>
         </main>
         <Footer />
@@ -85,7 +85,7 @@ export default function ClassPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 flex flex-col lg:flex-row gap-6">
+      <main className="container mx-auto flex-grow p-4 pb-12 flex flex-col lg:flex-row gap-6">
         <section className="flex-grow space-y-4">
           <nav className="text-sm flex items-center gap-2">
             <Link

--- a/src/pages/Contacto.tsx
+++ b/src/pages/Contacto.tsx
@@ -11,7 +11,7 @@ export default function Contacto() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 flex flex-col items-center gap-4">
+      <main className="container mx-auto flex-grow p-4 pb-12 flex flex-col items-center gap-4">
         <h1 className="text-5xl font-bold">Formulario de contacto</h1>
         <form className="border-2 border-gray-300 rounded p-4 flex flex-col gap-2 w-full max-w-md">
           {course && (

--- a/src/pages/CourseDetail.tsx
+++ b/src/pages/CourseDetail.tsx
@@ -54,7 +54,7 @@ export default function CourseDetail() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 flex flex-col items-start gap-6">
+      <main className="container mx-auto flex-grow p-4 pb-12 flex flex-col items-start gap-6">
         <nav className="text-base flex items-center gap-2">
           <button onClick={() => navigate(-1)} aria-label="Volver" className="p-1">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">

--- a/src/pages/CourseInscription.tsx
+++ b/src/pages/CourseInscription.tsx
@@ -44,7 +44,7 @@ export default function CourseInscription() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 flex flex-col items-center justify-center">
+      <main className="container mx-auto flex-grow p-4 pb-12 flex flex-col items-center justify-center">
         {course ? (
           <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-prose w-full border rounded-card p-card shadow-card bg-white dark:bg-gray-800">
             <h1 className="text-3xl font-bold text-center">Inscripción a {course.title}</h1>

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -41,7 +41,7 @@ export default function Courses() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-6">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-6">
         {isLogged && (
           <div className="space-y-4">
             <h1 className="text-3xl font-bold">Actualmente cursando</h1>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,7 +24,7 @@ export default function Dashboard() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex flex-col md:flex-row p-8 gap-8 items-start">
+      <main className="container mx-auto flex-grow flex flex-col md:flex-row p-8 pb-12 gap-8 items-start">
         <aside className="w-full md:w-56 flex justify-center md:block mb-4 md:mb-0">
           <ul className="space-y-2 text-center md:text-left">
             <li>

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -8,7 +8,7 @@ export default function ErrorPage() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-4 p-4 text-center">
+      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-4 p-4 pb-12 text-center">
         <h1 className="text-4xl font-bold">Ocurrió un error</h1>
         <p className="text-lg">Intenta nuevamente más tarde.</p>
         <Button onClick={() => navigate('/')}>Volver al inicio</Button>

--- a/src/pages/FinalExam.tsx
+++ b/src/pages/FinalExam.tsx
@@ -60,7 +60,7 @@ export default function FinalExam() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-4">
         <h1 className="text-5xl font-bold">
           Examen final - {course ? course.title : `Curso ${id}`}
         </h1>

--- a/src/pages/Forum.tsx
+++ b/src/pages/Forum.tsx
@@ -39,7 +39,7 @@ export default function Forum() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-8">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-8">
         <h1 className="text-5xl font-bold text-center">Foro de la comunidad</h1>
 
         <section className="bg-gray-100 dark:bg-gray-800 p-4 rounded space-y-4">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
                 </h1>
                 <p className="text-xl md:text-2xl text-black">Aprende y potencia tu carrera con cursos online dictados por profesionales del desarrollo web.</p>
                 <Link to="/cursos">
-                  <Button variant="primary" className="text-lg uppercase">Explorar Cursos</Button>
+                  <Button variant="primary" className="text-lg uppercase px-8 py-4">Explorar Cursos</Button>
                 </Link>
               </div>
             </div>
@@ -100,7 +100,7 @@ export default function Home() {
             </div>
           </div>
           <Link to="/cursos">
-            <Button variant="primary" className="text-lg uppercase">Explorar Cursos</Button>
+            <Button variant="primary" className="text-lg uppercase px-8 py-4">Explorar Cursos</Button>
           </Link>
         </section>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-        <main className="flex-grow">
+        <main className="flex-grow pt-4 pb-12">
           <section className="relative w-full overflow-hidden min-h-[600px] flex items-center">
             <div
               className="absolute inset-0 w-full h-full bg-cover bg-center -z-10"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
                 </h1>
                 <p className="text-xl md:text-2xl text-black">Aprende y potencia tu carrera con cursos online dictados por profesionales del desarrollo web.</p>
                 <Link to="/cursos">
-                  <Button variant="primary">Explorar cursos</Button>
+                  <Button variant="primary" className="text-lg uppercase">Explorar Cursos</Button>
                 </Link>
               </div>
             </div>
@@ -82,25 +82,25 @@ export default function Home() {
           <div className="grid md:grid-cols-3 gap-4 w-full">
             <div className="relative p-card rounded-card shadow-card flex flex-col items-center gap-3 border border-tertiary">
               <span className="absolute top-2 right-2 w-6 h-6 rounded-full bg-tertiary text-white flex items-center justify-center text-sm font-semibold">1</span>
-              <UserPlusIcon className="w-10 h-10 text-primary" />
-              <h3 className="text-lg font-semibold">Registrate gratis</h3>
-              <p className="text-sm text-center">Primero creá tu cuenta de usuario en la plataforma. Completa tus datos de contacto para que podamos identificarte. El registro es totalmente gratuito.</p>
+              <UserPlusIcon className="w-16 h-16 text-primary" />
+              <h3 className="text-3xl font-semibold">Registrate gratis</h3>
+              <p className="text-center">Primero creá tu cuenta de usuario en la plataforma. Completa tus datos de contacto para que podamos identificarte. El registro es totalmente gratuito.</p>
             </div>
             <div className="relative p-card rounded-card shadow-card flex flex-col items-center gap-3 border border-tertiary">
               <span className="absolute top-2 right-2 w-6 h-6 rounded-full bg-tertiary text-white flex items-center justify-center text-sm font-semibold">2</span>
-              <BookOpenIcon className="w-10 h-10 text-primary" />
-              <h3 className="text-lg font-semibold">Elegí un curso</h3>
-              <p className="text-sm text-center">Cuando hayas iniciado sesión podrás explorar nuestro catálogo de cursos. Revisa cada propuesta con calma y selecciona la que prefieras. Las clases se realizan paso a paso y a tu ritmo.</p>
+              <BookOpenIcon className="w-16 h-16 text-primary" />
+              <h3 className="text-3xl font-semibold">Elegí un curso</h3>
+              <p className="text-center">Cuando hayas iniciado sesión podrás explorar nuestro catálogo de cursos. Revisa cada propuesta con calma y selecciona la que prefieras. Las clases se realizan paso a paso y a tu ritmo.</p>
             </div>
             <div className="relative p-card rounded-card shadow-card flex flex-col items-center gap-3 border border-tertiary">
               <span className="absolute top-2 right-2 w-6 h-6 rounded-full bg-tertiary text-white flex items-center justify-center text-sm font-semibold">3</span>
-              <ClipboardDocumentCheckIcon className="w-10 h-10 text-primary" />
-              <h3 className="text-lg font-semibold">Realiza la evaluación</h3>
-              <p className="text-sm text-center">Al terminar las clases deberás contestar la evaluación final. Envía tus respuestas para demostrar lo aprendido. Si apruebas recibirás un certificado del curso.</p>
+              <ClipboardDocumentCheckIcon className="w-16 h-16 text-primary" />
+              <h3 className="text-3xl font-semibold">Realiza la evaluación</h3>
+              <p className="text-center">Al terminar las clases deberás contestar la evaluación final. Envía tus respuestas para demostrar lo aprendido. Si apruebas recibirás un certificado del curso.</p>
             </div>
           </div>
           <Link to="/cursos">
-            <Button variant="primary">Comenzar ahora</Button>
+            <Button variant="primary" className="text-lg uppercase">Explorar Cursos</Button>
           </Link>
         </section>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-        <main className="flex-grow pt-4 pb-12">
+      <main className="flex-grow">
           <section className="relative w-full overflow-hidden min-h-[600px] flex items-center">
             <div
               className="absolute inset-0 w-full h-full bg-cover bg-center -z-10"

--- a/src/pages/InscriptionSuccess.tsx
+++ b/src/pages/InscriptionSuccess.tsx
@@ -12,7 +12,7 @@ export default function InscriptionSuccess() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-6 p-4 text-center">
+      <main className="container mx-auto flex-grow flex flex-col items-center justify-center gap-6 p-4 pb-12 text-center">
         <CheckCircleIcon className="w-16 h-16 text-green-600" />
         <h1 className="text-6xl font-bold">¡Te inscribiste al curso con éxito!</h1>
         <p className="text-2xl">{courseName}</p>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -33,7 +33,7 @@ export default function Login() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow flex items-center justify-center p-4 pb-12 bg-gray-50 dark:bg-gray-900">
-        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2">
+        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2 md:min-h-[550px]">
           {/* Upload an SVG or PNG at public/images/auth-illustration.png
               representing modern and accessible online learning */}
           <img

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -33,7 +33,7 @@ export default function Login() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
-        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2">
+        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl mx-auto lg:grid-cols-2">
           {/* Upload an SVG or PNG at public/images/auth-illustration.png
               representing modern and accessible online learning */}
           <img

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,8 +32,8 @@ export default function Login() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="flex-grow flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
-        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl mx-auto lg:grid-cols-2">
+      <main className="flex-grow flex items-center justify-center p-4 pb-12 bg-gray-50 dark:bg-gray-900">
+        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2">
           {/* Upload an SVG or PNG at public/images/auth-illustration.png
               representing modern and accessible online learning */}
           <img

--- a/src/pages/Nosotros.tsx
+++ b/src/pages/Nosotros.tsx
@@ -39,7 +39,7 @@ export default function Nosotros() {
             <AcademicCapIcon className="w-16 h-16 text-purple-600" />
             <h2 className="text-4xl font-semibold">Misión y visión</h2>
             <p>
-              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro en que cualquier persona pueda crecer profesionalmente sin barreras.
+              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro en que cualquiera pueda crecer profesionalmente sin barreras.
             </p>
           </div>
         </section>

--- a/src/pages/Nosotros.tsx
+++ b/src/pages/Nosotros.tsx
@@ -21,25 +21,25 @@ export default function Nosotros() {
         </section>
 
         <section className="grid md:grid-cols-3 gap-8">
-          <div className="flex flex-col items-center text-center gap-2">
-            <UsersIcon className="w-12 h-12 text-blue-600" />
-            <h2 className="text-3xl font-semibold">Cómo trabajamos</h2>
+          <div className="flex flex-col items-center text-center gap-4">
+            <UsersIcon className="w-16 h-16 text-blue-600" />
+            <h2 className="text-4xl font-semibold">Cómo trabajamos</h2>
             <p>
-              Creamos contenido en pequeñas lecciones acompañado de proyectos reales. Fomentamos la participación en el foro y la colaboración entre estudiantes.
+              Creamos contenido en lecciones breves con proyectos reales. Incentivamos la participación en el foro y la colaboración permanente entre todos los estudiantes.
             </p>
           </div>
-          <div className="flex flex-col items-center text-center gap-2">
-            <HeartIcon className="w-12 h-12 text-red-600" />
-            <h2 className="text-3xl font-semibold">Nuestros valores</h2>
+          <div className="flex flex-col items-center text-center gap-4">
+            <HeartIcon className="w-16 h-16 text-red-600" />
+            <h2 className="text-4xl font-semibold">Nuestros valores</h2>
             <p>
-              Calidad, inclusión y aprendizaje continuo. Creemos que la educación debe ser accesible y motivadora para todas las personas.
+              Promovemos la calidad, la inclusión y el aprendizaje continuo. Creemos que la educación debe ser accesible, inspiradora y motivadora para todas las personas.
             </p>
           </div>
-          <div className="flex flex-col items-center text-center gap-2">
-            <AcademicCapIcon className="w-12 h-12 text-purple-600" />
-            <h2 className="text-3xl font-semibold">Misión y visión</h2>
+          <div className="flex flex-col items-center text-center gap-4">
+            <AcademicCapIcon className="w-16 h-16 text-purple-600" />
+            <h2 className="text-4xl font-semibold">Misión y visión</h2>
             <p>
-              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro donde cualquier persona pueda crecer profesionalmente sin barreras.
+              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro en el que cualquier persona pueda crecer profesionalmente sin barreras.
             </p>
           </div>
         </section>
@@ -48,7 +48,7 @@ export default function Nosotros() {
           <h2 className="text-4xl font-bold text-center">Nuestro equipo</h2>
           <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
             {instructors.map(i => (
-              <div key={i.name} className="p-card rounded-card shadow-card text-center space-y-2">
+              <div key={i.name} className="p-card rounded-card shadow-card text-center space-y-2 border border-tertiary">
                 <img src={getAssetUrl(i.avatar)} alt={i.name} className="w-[240px] h-[240px] object-cover rounded-full mx-auto" />
                 <h3 className="font-semibold">{i.name}</h3>
                 <p className="text-base text-gray-600">{i.role}</p>

--- a/src/pages/Nosotros.tsx
+++ b/src/pages/Nosotros.tsx
@@ -12,7 +12,7 @@ export default function Nosotros() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-12">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-12">
         <section className="text-center space-y-4">
           <h1 className="text-6xl font-extrabold">Sobre Aula Digital Ciudadana</h1>
           <p className="text-xl">
@@ -39,7 +39,7 @@ export default function Nosotros() {
             <AcademicCapIcon className="w-16 h-16 text-purple-600" />
             <h2 className="text-4xl font-semibold">Misión y visión</h2>
             <p>
-              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro en el que cualquier persona pueda crecer profesionalmente sin barreras.
+              Buscamos formar una comunidad que comparta conocimiento y oportunidades. Soñamos con un futuro en que cualquier persona pueda crecer profesionalmente sin barreras.
             </p>
           </div>
         </section>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,20 +9,25 @@ export default function NotFound() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex items-center justify-center p-4 min-h-[800px]">
-        <div className="flex flex-col items-center text-center gap-8">
-          <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent pb-2">
-            Error 404 - Página no encontrada
-          </h1>
-          <p className="text-xl">
-            Ups... Lo lamento, la ruta que estás buscando no existe.
-          </p>
+      <main className="container mx-auto flex-grow flex items-center justify-center p-4 min-h-[600px]">
+        <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
+          <div className="flex flex-col items-start text-left max-w-md">
+            <br />
+            <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent pb-2">
+              Error 404 - Página no encontrada
+            </h1>
+            <br />
+            <p className="text-xl mb-6">
+              Ups... Lo lamento, la ruta que estás buscando no existe.
+            </p>
+            <Button onClick={() => navigate('/')}>Volver al inicio</Button>
+          </div>
+
           <img
             src={getAssetUrl('/images/error404.png')}
             alt="falla en la página"
-            className="w-full max-w-lg object-contain"
+            className="md:w-[400px] lg:w-[500px] object-contain"
           />
-          <Button onClick={() => navigate('/')}>Volver al inicio</Button>
         </div>
       </main>
       <Footer />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -13,14 +13,14 @@ export default function NotFound() {
         <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
           <div className="flex flex-col items-start text-left max-w-md">
             <br />
-            <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent pb-2">
+            <h1 className="text-6xl md:text-7xl font-extrabold text-primary pb-2">
               Error 404 - Página no encontrada
             </h1>
             <br />
             <p className="text-xl mb-6">
               Ups... Lo lamento, la ruta que estás buscando no existe.
             </p>
-            <Button onClick={() => navigate('/')}>Volver al inicio</Button>
+            <Button onClick={() => navigate('/')} className="text-lg uppercase px-8 py-4">Volver al inicio</Button>
           </div>
 
           <img

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex items-center justify-center p-4 min-h-[600px]">
+      <main className="container mx-auto flex-grow flex items-center justify-center p-4 pb-12 min-h-[600px]">
         <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
           <div className="flex flex-col items-start text-left max-w-md">
             <br />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,25 +9,20 @@ export default function NotFound() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow flex items-center justify-center p-4">
-        <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
-          <div className="flex flex-col items-start text-left max-w-md">
-            <br />
-            <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent pb-2">
-              Error 404 - Página no encontrada
-            </h1>
-            <br />
-            <p className="text-xl mb-6">
-              Ups... Lo lamento, la ruta que estás buscando no existe.
-            </p>
-            <Button onClick={() => navigate('/')}>Volver al inicio</Button>
-          </div>
-
+      <main className="container mx-auto flex-grow flex items-center justify-center p-4 min-h-[800px]">
+        <div className="flex flex-col items-center text-center gap-8">
+          <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent pb-2">
+            Error 404 - Página no encontrada
+          </h1>
+          <p className="text-xl">
+            Ups... Lo lamento, la ruta que estás buscando no existe.
+          </p>
           <img
             src={getAssetUrl('/images/error404.png')}
             alt="falla en la página"
-            className="md:w-[400px] lg:w-[500px] object-contain"
+            className="w-full max-w-lg object-contain"
           />
+          <Button onClick={() => navigate('/')}>Volver al inicio</Button>
         </div>
       </main>
       <Footer />

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -12,7 +12,7 @@ export default function Profile() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-4">
         <h1 className="text-3xl font-bold">Perfil de usuario</h1>
         <div className="flex flex-col gap-4 max-w-sm">
           <input className="border p-2 rounded" value={name} onChange={e => setName(e.target.value)} placeholder="Nombre" />

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -8,7 +8,7 @@ export default function Register() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="flex-grow flex items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
+      <main className="flex-grow flex items-center justify-center p-4 pb-12 bg-gray-50 dark:bg-gray-900">
         <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2">
           {/* Upload an SVG or PNG at public/images/auth-illustration.png
               representing modern and accessible online learning */}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -9,7 +9,7 @@ export default function Register() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow flex items-center justify-center p-4 pb-12 bg-gray-50 dark:bg-gray-900">
-        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2">
+        <div className="bg-white rounded-2xl shadow-lg overflow-hidden grid w-full max-w-4xl lg:grid-cols-2 md:min-h-[550px]">
           {/* Upload an SVG or PNG at public/images/auth-illustration.png
               representing modern and accessible online learning */}
           <img

--- a/src/pages/UserFlow.tsx
+++ b/src/pages/UserFlow.tsx
@@ -44,7 +44,7 @@ export default function UserFlow() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-4">
         <h1 className="text-3xl font-bold">Flujo de usuario</h1>
         <ol className="list-decimal pl-5 space-y-2">
           {steps.map(step => (

--- a/src/pages/Wireframes.tsx
+++ b/src/pages/Wireframes.tsx
@@ -25,7 +25,7 @@ export default function Wireframes() {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="container mx-auto flex-grow p-4 space-y-4">
+      <main className="container mx-auto flex-grow p-4 pb-12 space-y-4">
         <h1 className="text-3xl font-bold">Wireframes</h1>
         <ul className="list-disc pl-5 space-y-1">
           {files.map(file => (


### PR DESCRIPTION
## Summary
- enlarge CTA buttons on the Home page and rename to **Explorar Cursos**
- increase icon, title and text size for the "¿Cómo inscribirse?" cards

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c4911bca4832faa196786d1ee0c84